### PR TITLE
Upgrade to Spring Security 6 and modernize Google API client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ dependencies {
     implementation 'com.google.api-client:google-api-client-gson:2.3.0'
     implementation 'com.google.api-client:google-api-client:1.35.0'
     implementation 'com.google.apis:google-api-services-gmail:v1-rev20211108-1.32.1'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
     implementation 'com.sun.mail:jakarta.mail:2.0.1'
 
     implementation 'org.springframework.security:spring-security-oauth2-resource-server'

--- a/src/main/kotlin/cta/app/config/SecurityConfig.kt
+++ b/src/main/kotlin/cta/app/config/SecurityConfig.kt
@@ -75,19 +75,18 @@ class SecurityConfig(
     public fun filterChain(
         http: HttpSecurity,
         authenticationConfiguration: AuthenticationConfiguration): SecurityFilterChain {
-        http.csrf().disable()
-        http.headers().httpStrictTransportSecurity().disable()
+        http.csrf { it.disable() }
+        http.headers { headers -> headers.httpStrictTransportSecurity { it.disable() } }
         //http.addFilterBefore(corsFilter, SessionManagementFilter::class.java)
         http.addFilterBefore(TokenAuthenticationFilter(authService), BasicAuthenticationFilter::class.java)
         http.addFilterBefore(secretAuthenticationFilter(authenticationConfiguration), UsernamePasswordAuthenticationFilter::class.java)
-        http.oauth2ResourceServer().jwt().jwtAuthenticationConverter(Auth0TokenConverter())
-        http.authorizeRequests()
-            .anyRequest().permitAll()
-            .and()
-            .formLogin()
-            .loginPage("/login")
-            .defaultSuccessUrl("/login", true)
-            .failureUrl("/login?error")
+        http.oauth2ResourceServer { it.jwt { jwt -> jwt.jwtAuthenticationConverter(Auth0TokenConverter()) } }
+        http.authorizeHttpRequests { it.anyRequest().permitAll() }
+        http.formLogin { form ->
+            form.loginPage("/login")
+                .defaultSuccessUrl("/login", true)
+                .failureUrl("/login?error")
+        }
         return http.build()
     }
 }

--- a/src/main/kotlin/cta/app/graphql/mutations/KitMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/KitMutations.kt
@@ -82,7 +82,6 @@ class KitMutations(
 
     @MutationMapping
     fun updateKit(@Argument @Valid data: UpdateKitInput): Kit {
-        val self = this
         val entity = kits.findOne(filterService.kitFilter().and(QKit.kit.id.eq(data.id))).toNullable()
             ?: throw EntityNotFoundException("Unable to locate a kit with id: ${data.id}")
 
@@ -93,7 +92,7 @@ class KitMutations(
                 statusUpdatedAt = Instant.now()
             }
 
-            if (location != null && location.isNotBlank() && (coordinates == null || coordinates?.input != location)) {
+            if (location.isNotBlank() && (coordinates == null || coordinates?.input != location)) {
                 coordinates = locationService.findCoordinates(location)
             }
 
@@ -153,7 +152,6 @@ class KitMutations(
 
     @MutationMapping
     fun autoUpdateKit(@Argument @Valid data: AutoUpdateKitInput): Kit {
-        val self = this
         val entity = kits.findOne(filterService.kitFilter().and(QKit.kit.id.eq(data.id))).toNullable()
             ?: throw RuntimeException("Unable to locate a kit with CTA id: ${data.id}")
 
@@ -298,7 +296,7 @@ data class UpdateKitInput(
         return entity.apply {
             type = self.type
             status = self.status
-            model = self.model ?: model
+            model = self.model
             age = self.age ?: age
             attributes = attributes
             archived = self.archived ?: archived
@@ -306,7 +304,7 @@ data class UpdateKitInput(
             deviceVersion = self.deviceVersion ?: deviceVersion
             serialNo = self.serialNo ?: serialNo
             storageCapacity = self.storageCapacity ?: storageCapacity
-            typeOfStorage = self.typeOfStorage ?: (typeOfStorage ?: KitStorageType.UNKNOWN)
+            typeOfStorage = self.typeOfStorage
             ramCapacity = self.ramCapacity ?: ramCapacity
             cpuType = self.cpuType ?: cpuType
             tpmVersion = self.tpmVersion ?: tpmVersion
@@ -385,9 +383,9 @@ data class AutoUpdateKitInput(
         val self = this
         return entity.apply {
             val previousStatus = status
-            type = self.type ?: type ?: (type ?: KitType.OTHER)
+            type = self.type ?: type
             model = self.model ?: model
-            status = self.status ?: status ?: (status ?: KitStatus.DONATION_NEW)
+            status = self.status ?: status
             // Update statusUpdatedAt if status has changed
             if (previousStatus != status) {
                 statusUpdatedAt = Instant.now()
@@ -396,7 +394,7 @@ data class AutoUpdateKitInput(
             deviceVersion = self.deviceVersion ?: deviceVersion
             serialNo = self.serialNo ?: serialNo
             storageCapacity = self.storageCapacity ?: storageCapacity
-            typeOfStorage = self.typeOfStorage ?: (typeOfStorage ?: KitStorageType.UNKNOWN)
+            typeOfStorage = self.typeOfStorage ?: typeOfStorage
             ramCapacity = self.ramCapacity ?: ramCapacity
             cpuType = self.cpuType ?: cpuType
             tpmVersion = self.tpmVersion ?: tpmVersion
@@ -421,10 +419,6 @@ data class KitSubStatusInput(
 {
     fun apply(entity: Kit): KitSubStatus {
         val self = this
-        if(entity.subStatus == null) {
-            entity.subStatus = KitSubStatus()
-        }
-
         return entity.subStatus.apply {
             installationOfOSFailed = self.installationOfOSFailed
             wipeFailed = self.wipeFailed

--- a/src/main/kotlin/cta/app/models.kt
+++ b/src/main/kotlin/cta/app/models.kt
@@ -27,7 +27,7 @@ import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.Formula
 import org.hibernate.annotations.JdbcTypeCode
-import org.hibernate.annotations.OrderBy
+import org.hibernate.annotations.SQLOrder
 import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.envers.AuditTable
 import org.hibernate.envers.Audited
@@ -217,7 +217,7 @@ class Kit(
         orphanRemoval = true,
         mappedBy = "kit"
     )
-    @OrderBy(clause = "updatedAt DESC")
+    @SQLOrder("updatedAt DESC")
     var notes: MutableSet<Note> = mutableSetOf(),
 
     @JdbcTypeCode(SqlTypes.JSON)
@@ -375,7 +375,7 @@ class ReferringOrganisation(
         orphanRemoval = true,
         mappedBy = "referringOrganisation"
     )
-    @OrderBy(clause = "updatedAt DESC")
+    @SQLOrder("updatedAt DESC")
     var referringOrganisationContacts: MutableSet<ReferringOrganisationContact> = mutableSetOf(),
     @NotAudited
     @OneToMany(
@@ -384,7 +384,7 @@ class ReferringOrganisation(
         orphanRemoval = true,
         mappedBy = "referringOrganisation"
     )
-    @OrderBy(clause = "updatedAt DESC")
+    @SQLOrder("updatedAt DESC")
     var referringOrganisationNotes: MutableSet<ReferringOrganisationNote> = mutableSetOf()
 ) {
     fun addContact(contact: ReferringOrganisationContact) {
@@ -437,7 +437,7 @@ class ReferringOrganisationContact(
         orphanRemoval = true,
         mappedBy = "referringOrganisationContact"
     )
-    @OrderBy(clause = "updatedAt DESC")
+    @SQLOrder("updatedAt DESC")
     var referringOrganisationContactNotes: MutableSet<ReferringOrganisationContactNote> = mutableSetOf()
 
 
@@ -532,7 +532,7 @@ class DeviceRequest(
         orphanRemoval = true,
         mappedBy = "deviceRequest"
     )
-    @OrderBy(clause = "updatedAt DESC")
+    @SQLOrder("updatedAt DESC")
     var deviceRequestNotes: MutableSet<DeviceRequestNote> = mutableSetOf(),
     @NotAudited
     @OneToMany(

--- a/src/main/kotlin/cta/app/services/DeviceRequestService.kt
+++ b/src/main/kotlin/cta/app/services/DeviceRequestService.kt
@@ -75,7 +75,6 @@ class DeviceRequestService(
 </head>
 <body class="c5 doc-content">
 """;
-        val typeFormURL = "https://ghjngk6ao4g.typeform.com/to/TzlNC6kN";
         val emailBody = """
 Dear ${request.referringOrganisationContact.fullName} of ${request.referringOrganisationContact.referringOrganisation.name}<br>
 <br>
@@ -161,7 +160,6 @@ Best wishes <br>
 </head>
 <body class="c5 doc-content">
 """;
-        val typeFormURL = "https://ghjngk6ao4g.typeform.com/to/TzlNC6kN";
         val emailBody = """
 Dear ${request.referringOrganisationContact.fullName} of ${request.referringOrganisationContact.referringOrganisation.name}<br>
 <br>

--- a/src/main/kotlin/cta/app/services/FilterService.kt
+++ b/src/main/kotlin/cta/app/services/FilterService.kt
@@ -39,7 +39,7 @@ class FilterService {
 
     fun kitFilter(): BooleanBuilder {
         val filter = BooleanBuilder()
-        val user = currentUser ?: return filter
+        currentUser ?: return filter
         if (hasAuthority("admin:kits")) {
             return filter
         }
@@ -48,7 +48,7 @@ class FilterService {
 
     fun donorFilter(): BooleanBuilder {
         val filter = BooleanBuilder()
-        val user = currentUser ?: return filter
+        currentUser ?: return filter
         if (hasAuthority("admin:donors")) {
             return filter
         }

--- a/src/main/kotlin/cta/app/services/MailService.kt
+++ b/src/main/kotlin/cta/app/services/MailService.kt
@@ -1,12 +1,13 @@
 package cta.app.services
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
-import com.google.api.client.util.Base64
 import com.google.api.services.gmail.Gmail
 import com.google.api.services.gmail.model.Message
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.UserCredentials
 import java.io.ByteArrayOutputStream
+import java.util.Base64
 import java.util.Properties
 import jakarta.mail.Session
 import jakarta.mail.internet.InternetAddress
@@ -35,15 +36,13 @@ class MailService {
     val gmail: Gmail by lazy {
         val jsonFactory = GsonFactory.getDefaultInstance()
         val transport = GoogleNetHttpTransport.newTrustedTransport()
-        val credential = GoogleCredential.Builder()
-            .setJsonFactory(jsonFactory)
-            .setTransport(transport)
-            .setClientSecrets(clientId, clientSecret)
-            .build()
+        val credentials = UserCredentials.newBuilder()
+            .setClientId(clientId)
+            .setClientSecret(clientSecret)
             .setRefreshToken(refreshToken)
+            .build()
         logger.info("MailService startup. Enabled: $emailEnabled FromAddress: $address")
-        credential.refreshToken()
-        Gmail.Builder(transport, jsonFactory, credential).setApplicationName("Community Techaid").build()
+        Gmail.Builder(transport, jsonFactory, HttpCredentialsAdapter(credentials)).setApplicationName("Community Techaid").build()
     }
 
     fun sendMessage(message: MimeMessage): Message = sendMessage(createMessageWithEmail(message))    
@@ -76,7 +75,7 @@ fun createMessageWithEmail(emailContent: MimeMessage): Message {
     val buffer = ByteArrayOutputStream()
     emailContent.writeTo(buffer)
     val bytes = buffer.toByteArray()
-    val encodedEmail = Base64.encodeBase64URLSafeString(bytes)
+    val encodedEmail = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     val message = Message()
     message.raw = encodedEmail
     return message

--- a/src/main/kotlin/cta/commands/DumpSchema.kt
+++ b/src/main/kotlin/cta/commands/DumpSchema.kt
@@ -45,7 +45,7 @@ class DumpSchema(
     override fun call(): Int {
         val registry = StandardServiceRegistryBuilder()
             .applySettings(jpaProperties.properties as Map<String, Any>?)
-            .applySetting(AvailableSettings.DATASOURCE, dataSource)
+            .applySetting(AvailableSettings.JAKARTA_NON_JTA_DATASOURCE, dataSource)
             .applySetting(AvailableSettings.PHYSICAL_NAMING_STRATEGY, CamelCaseToUnderscoresNamingStrategy::class.java)
             .applySetting(AvailableSettings.IMPLICIT_NAMING_STRATEGY, SpringImplicitNamingStrategy::class.java)
             .applySetting(AvailableSettings.DIALECT, PostgreSQLDialect::class.java)


### PR DESCRIPTION
## Summary
This PR modernizes the codebase by upgrading to Spring Security 6 lambda-based DSL configuration and updating Google API authentication to use the newer `google-auth-library-oauth2-http` library. Additionally, it updates Hibernate annotations to their latest versions and removes unused code.

## Key Changes

- **Spring Security 6 Migration**: Converted deprecated `http.csrf().disable()` and chained configuration methods to the new lambda-based DSL syntax (e.g., `http.csrf { it.disable() }`)
  - Updated `authorizeRequests()` to `authorizeHttpRequests()`
  - Refactored `formLogin()` configuration to use lambda syntax
  - Updated `oauth2ResourceServer()` and `jwt()` configurations to lambda-based API

- **Google API Authentication**: Replaced deprecated `GoogleCredential` with `UserCredentials` and `HttpCredentialsAdapter`
  - Updated Base64 encoding from `com.google.api.client.util.Base64` to Java's standard `java.util.Base64`
  - Removed manual `refreshToken()` call as it's now handled automatically

- **Hibernate Annotation Updates**: 
  - Replaced deprecated `@OrderBy` with `@SQLOrder` annotation across multiple entity classes (Kit, ReferringOrganisation, ReferringOrganisationContact, DeviceRequest)

- **Code Cleanup**:
  - Removed unused `val self = this` variable assignments in KitMutations
  - Simplified null-coalescing logic in UpdateKitInput and AutoUpdateKitInput (removed redundant fallback defaults)
  - Removed unused `typeFormURL` variables in DeviceRequestService
  - Removed unnecessary null-check and initialization in KitSubStatusInput.apply()
  - Simplified FilterService by removing unused variable assignments

- **Hibernate Configuration**: Updated DumpSchema to use `JAKARTA_NON_JTA_DATASOURCE` setting instead of deprecated `DATASOURCE`

## Notable Implementation Details
- The Spring Security lambda DSL provides better type safety and IDE support compared to the deprecated chained method approach
- Google API credentials are now managed through the standard `google-auth-library-oauth2-http` library, which is more actively maintained
- All changes maintain backward compatibility in functionality while modernizing the underlying APIs

https://claude.ai/code/session_01B7FhLxnxyeBZ9SUJDUGjAu