### PR TITLE
Upgrade embedded-database-spring-test from 1.5.3 to 2.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ dependencies {
     kapt "com.querydsl:querydsl-apt:5.0.0:jakarta"
     runtimeOnly 'org.postgresql:postgresql'
     /* Making use of embedded postgres db when running unit tests */
-    testImplementation 'io.zonky.test:embedded-database-spring-test:1.5.3'
+    testImplementation 'io.zonky.test:embedded-database-spring-test:2.5.1'
     /* Providing In-Memory H2 database as the default spring data-source */
     testImplementation 'com.h2database:h2:1.4.200'
     implementation "org.hibernate:hibernate-envers:${hibernate_version}"


### PR DESCRIPTION
## Summary
Updated the embedded-database-spring-test dependency to a newer major version to benefit from bug fixes, performance improvements, and compatibility enhancements.

## Changes
- Upgraded `io.zonky.test:embedded-database-spring-test` from version 1.5.3 to 2.5.1

## Details
This is a significant version bump (1.5.3 → 2.5.1) that brings the embedded PostgreSQL test database library up to date. This upgrade should improve test reliability and compatibility with newer Spring Boot and PostgreSQL versions.

https://claude.ai/code/session_01QhHCJkpe576dB1GSmPNTyf