### PR TITLE
Fix test ambiguous-driver error and restrict CI to dev pushes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI/CD
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [dev]
   # Manual promotion trigger — select an environment from the dropdown in the
   # GitHub Actions UI to deploy the current branch to that environment.
   workflow_dispatch:

--- a/src/test/kotlin/ju/ma/ApplicationTest.kt
+++ b/src/test/kotlin/ju/ma/ApplicationTest.kt
@@ -10,7 +10,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@AutoConfigureEmbeddedDatabase
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
 class ApplicationTest {
 
     @MockBean


### PR DESCRIPTION
embedded-database-spring-test 2.x requires the database type to be explicit when multiple drivers (PostgreSQL + H2) are on the test classpath; without it, DefaultProviderResolver throws an ambiguous- detection error. Adding DatabaseType.POSTGRES removes the ambiguity and lets zonky select the Docker-backed PostgreSQL provider, which is available on the GitHub Actions ubuntu-latest runner.

Also removes the pull_request CI trigger so builds only fire on direct pushes to dev (and manual dispatch), not on every PR update.

https://claude.ai/code/session_01QhHCJkpe576dB1GSmPNTyf