### PR TITLE
Fix missing test properties and GraphQlEndpointTest driver ambiguity

### DIFF
--- a/src/test/kotlin/cta/graphql/GraphQlEndpointTest.kt
+++ b/src/test/kotlin/cta/graphql/GraphQlEndpointTest.kt
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
-@AutoConfigureEmbeddedDatabase
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
 class GraphQlEndpointTest {
 
     @MockBean

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,12 @@
 auth0:
   token-attribute: https://test.example.com
+  audience: ''
+  domain: ''
+  client-id: ''
+  client-secret: ''
+
+auth:
+  admin-secret: password
 
 spring:
   security:
@@ -7,3 +14,14 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: https://test.example.com/
+
+gmail:
+  client-id: ''
+  client-secret: ''
+  refresh-token: ''
+  address: test@example.com
+  enabled: false
+  bcc-address: test@example.com
+
+typeform:
+  key: ''


### PR DESCRIPTION
The test application.yml replaces (not merges with) the main one on the Gradle test classpath, so every @Value without an inline default that is only defined in the main YAML fails to resolve. Add the required properties (auth.admin-secret, auth0.*, gmail.*, typeform.key) with safe test values so the context can start.

Also specify DatabaseType.POSTGRES on GraphQlEndpointTest for the same reason as ApplicationTest — zonky 2.x requires an explicit type when both H2 and PostgreSQL drivers are on the classpath.

https://claude.ai/code/session_01QhHCJkpe576dB1GSmPNTyf