### PR TITLE
Switch to pre-built Docker image deployment via GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,36 +52,62 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Full history needed for the git push to Dokku
-          fetch-depth: 0
 
-      # Build the Docker image in CI to catch compilation failures before deploying.
-      # Dokku rebuilds from the Dockerfile on the server, but this step validates
-      # the build succeeds first.
+      # Build the Docker image on GitHub Actions so the dev server doesn't
+      # need to compile the Gradle project or run Docker builds.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
-          tags: techaid-api:${{ github.sha }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest
           # Cache Docker layers across runs to speed up the Gradle + JDK compilation step
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # DOKKU_SSH_PRIVATE_KEY and DOKKU_HOST must be set as secrets on each
-      # GitHub environment (Development / Production) separately, so that each
-      # environment points at its own Dokku server.
+      # Deploy the pre-built image to Dokku via SSH.  This uses Dokku's
+      # `git:from-image` command so the server pulls the image instead of
+      # building from source, keeping load off the lightweight dev VM.
+      #
+      # Required secrets per GitHub environment (Development / Production):
+      #   DOKKU_SSH_PRIVATE_KEY – private key whose public half is in
+      #                           `dokku ssh-keys:list` on the server
+      #   DOKKU_HOST            – hostname or IP of the Dokku server
+      #
+      # Required one-time Dokku server setup:
+      #   dokku docker-options:add api deploy "--pull=always"
       - name: Deploy to Dokku
         env:
           DOKKU_SSH_PRIVATE_KEY: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
           DOKKU_HOST: ${{ secrets.DOKKU_HOST }}
         run: |
+          # Fail loudly if secrets are missing
+          if [ -z "$DOKKU_SSH_PRIVATE_KEY" ]; then
+            echo "::error::DOKKU_SSH_PRIVATE_KEY is not set. Configure it in the GitHub environment secrets."
+            exit 1
+          fi
+          if [ -z "$DOKKU_HOST" ]; then
+            echo "::error::DOKKU_HOST is not set. Configure it in the GitHub environment secrets."
+            exit 1
+          fi
+
           mkdir -p ~/.ssh
           echo "$DOKKU_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H "$DOKKU_HOST" >> ~/.ssh/known_hosts
-          git push "dokku@${DOKKU_HOST}:api" HEAD:refs/heads/master
+          ssh-keyscan -H "$DOKKU_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          IMAGE="ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          echo "Deploying image: $IMAGE"
+          ssh "dokku@${DOKKU_HOST}" git:from-image api "$IMAGE"


### PR DESCRIPTION
## Summary
This PR refactors the CI/CD pipeline to build Docker images in GitHub Actions and push them to GitHub Container Registry (GHCR), then deploy pre-built images to Dokku instead of having the server build from source. This reduces load on the lightweight development VM by offloading compilation and Docker builds to GitHub's infrastructure.

## Key Changes
- **Removed full git history requirement** – `fetch-depth: 0` is no longer needed since we're not pushing git refs to Dokku
- **Added Docker image push to GHCR** – Images are now built and pushed to `ghcr.io/${{ github.repository }}` with both commit SHA and `latest` tags
- **Changed deployment strategy** – Replaced `git push` to Dokku with `git:from-image` command, which pulls the pre-built image instead of building from source
- **Added GitHub Container Registry authentication** – New login step using `GITHUB_TOKEN` to authenticate with GHCR
- **Improved error handling** – Added explicit validation for required secrets (`DOKKU_SSH_PRIVATE_KEY` and `DOKKU_HOST`) with clear error messages
- **Enhanced documentation** – Added detailed comments explaining the deployment approach and required Dokku server setup
- **Improved logging** – Added image name output before deployment for better visibility

## Implementation Details
- Docker layer caching is preserved via GitHub Actions cache (`type=gha`) to speed up Gradle and JDK compilation
- SSH key setup and host key scanning remain unchanged for secure Dokku communication
- The deployment now requires one-time Dokku server setup: `dokku docker-options:add api deploy "--pull=always"` to ensure the server always pulls the latest image
- SSH output redirection suppressed for `ssh-keyscan` to reduce noise in logs

https://claude.ai/code/session_01R7gtoC7ofyksnaijs1AREc