### PR TITLE
Fix Docker tag error: lowercase the GHCR image name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Lowercase image name
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       # Build the Docker image on GitHub Actions so the dev server doesn't
       # need to compile the Gradle project or run Docker builds.
       - name: Set up Docker Buildx
@@ -71,8 +75,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ steps.image.outputs.name }}:${{ github.sha }}
+            ${{ steps.image.outputs.name }}:latest
           # Cache Docker layers across runs to speed up the Gradle + JDK compilation step
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -108,6 +112,6 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H "$DOKKU_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-          IMAGE="ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          IMAGE="${{ steps.image.outputs.name }}:${{ github.sha }}"
           echo "Deploying image: $IMAGE"
           ssh "dokku@${DOKKU_HOST}" git:from-image api "$IMAGE"


### PR DESCRIPTION
github.repository preserves original casing (CommunityTechaid/...) but Docker tags must be all lowercase. Use Bash lowercase expansion (${GITHUB_REPOSITORY,,}) to normalize the image name.

https://claude.ai/code/session_01R7gtoC7ofyksnaijs1AREc