### PR TITLE
Grant packages:write permission to deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     # Auto-deploy on dev pushes; also runs when manually dispatched
     if: (github.ref == 'refs/heads/dev' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
     # Uses Development environment on auto-deploy, or the selected environment


### PR DESCRIPTION
The GITHUB_TOKEN needs explicit packages:write permission to push Docker images to GHCR for an organization repository.

https://claude.ai/code/session_01R7gtoC7ofyksnaijs1AREc