### PR TITLE
Add SSH debugging to deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,16 @@ jobs:
           fi
 
           mkdir -p ~/.ssh
-          echo "$DOKKU_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          printf '%s\n' "$DOKKU_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H "$DOKKU_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          echo "::group::ssh-keyscan"
+          ssh-keyscan -H "$DOKKU_HOST" >> ~/.ssh/known_hosts
+          echo "::endgroup::"
+
+          # Verify SSH connectivity before attempting deploy
+          echo "Testing SSH connection..."
+          ssh -v -o ConnectTimeout=10 "dokku@${DOKKU_HOST}" version
 
           IMAGE="${{ steps.image.outputs.name }}:${{ github.sha }}"
           echo "Deploying image: $IMAGE"


### PR DESCRIPTION
- Stop suppressing ssh-keyscan stderr so host key errors are visible
- Use printf instead of echo for the private key (safer with newlines)
- Add verbose SSH connectivity test before attempting deploy
- Add ConnectTimeout to fail fast if host is unreachable

https://claude.ai/code/session_01R7gtoC7ofyksnaijs1AREc