### PR TITLE
Fix Docker build: pass git commit as build arg instead of running git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: |
             ${{ steps.image.outputs.name }}:${{ github.sha }}
             ${{ steps.image.outputs.name }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # NOTE: This is the production and uat version. Please use Dockerfile.dev for local development testing
-FROM gradle:8.6-jdk17 as builder
+FROM gradle:8.6-jdk17 AS builder
 USER root
+ARG GIT_COMMIT=unknown
 COPY ./src /app/src
 COPY ./build.gradle settings.gradle /app/
-RUN gradle -p /app clean build -x test
+RUN gradle -p /app clean build -x test -PgitCommit=${GIT_COMMIT}
 
 FROM eclipse-temurin:17-jre-alpine
 COPY --from=builder /app/build/libs/*.jar /app/app.jar

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ springBoot {
     buildInfo {
         properties {
             additional = [
-                'git.commit': providers.exec {
-                    commandLine 'git', 'rev-parse', '--short', 'HEAD'
-                }.standardOutput.asText.map { it.trim() }
+                'git.commit': providers.provider {
+                    project.findProperty('gitCommit') ?: 'unknown'
+                }
             ]
         }
     }


### PR DESCRIPTION
The Dockerfile only copies src/ and build.gradle — no .git directory — so `git rev-parse` fails inside the container. Instead, pass the commit hash as a Docker build arg (GIT_COMMIT) and forward it to Gradle via -PgitCommit. Falls back to 'unknown' for local builds.

https://claude.ai/code/session_01R7gtoC7ofyksnaijs1AREc