### PR TITLE
fix: annotate long-text entity fields to prevent Hibernate ALTER failure

### DIFF
--- a/src/main/kotlin/cta/app/BlogModels.kt
+++ b/src/main/kotlin/cta/app/BlogModels.kt
@@ -1,5 +1,6 @@
 package cta.app
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -24,6 +25,7 @@ class Post(
     var slug: String,
     var published: Boolean,
     var secured: Boolean,
+    @Column(columnDefinition = "TEXT")
     var content: String,
     @CreationTimestamp
     var createdAt: Instant = Instant.now(),

--- a/src/main/kotlin/cta/app/DeviceRequestModels.kt
+++ b/src/main/kotlin/cta/app/DeviceRequestModels.kt
@@ -92,6 +92,7 @@ class DeviceRequest(
     var isSales: Boolean = false,
     var clientRef: String,
     var borough: String?,
+    @Column(columnDefinition = "TEXT")
     var details: String,
     @NotAudited
     @Formula(


### PR DESCRIPTION
Hibernate 6 (Spring Boot 3.4.x) defaults unannotated String fields to varchar(255) and attempts to ALTER the column on startup with ddl-auto=update. The staging/production DB already has TEXT data in these columns, so the ALTER fails with "value too long for type character varying(255)".

Fix: add @Column(columnDefinition = "TEXT") to:
- Post.content (BlogModels.kt)
- DeviceRequest.details (DeviceRequestModels.kt)

Other content/notes fields in KitModels and OrganisationModels already had @Column(length = 4096) so were not affected.