### PR TITLE
Add bulk kit assignment mutation for device requests

### DIFF
--- a/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
@@ -8,7 +8,9 @@ import cta.app.DeviceRequestNote
 import cta.app.DeviceRequestNoteRepository
 import cta.app.DeviceRequestRepository
 import cta.app.DeviceRequestStatus
+import cta.app.KitRepository
 import cta.app.KitStatus
+import cta.app.QKit
 import cta.app.ReferringOrganisationContactRepository
 import cta.app.services.FilterService
 import cta.app.services.MailService
@@ -100,7 +102,8 @@ class DeviceRequestMutations(
     private val referringOrganisationContacts: ReferringOrganisationContactRepository,
     private val filterService: FilterService,
     private val deviceRequestNotes: DeviceRequestNoteRepository,
-    private val mailService: MailService
+    private val mailService: MailService,
+    private val kits: KitRepository
 )  {
 
     @MutationMapping
@@ -191,6 +194,23 @@ class DeviceRequestMutations(
             ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.id}")
 
         return data.apply(entity)
+    }
+
+    @PreAuthorize("hasAnyAuthority('write:organisations')")
+    @MutationMapping
+    fun assignKitsToDeviceRequest(@Argument @Valid data: BulkKitAssignmentInput): DeviceRequest {
+        val deviceRequest = deviceRequests.findById(data.deviceRequestId).toNullable()
+            ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.deviceRequestId}")
+
+        val predicate = filterService.kitFilter().and(QKit.kit.id.`in`(data.kitIds))
+        val kitsToAssign = kits.findAll(predicate)
+
+        kitsToAssign.forEach { kit ->
+            kit.deviceRequest?.removeKit(kit)
+            deviceRequest.addKit(kit)
+        }
+
+        return deviceRequests.save(deviceRequest)
     }
 
     @PreAuthorize("hasAnyAuthority('delete:organisations')")
@@ -298,6 +318,12 @@ data class UpdateDeviceRequestInput(
         }
     }
 }
+
+data class BulkKitAssignmentInput(
+    @get:NotNull
+    val deviceRequestId: Long,
+    val kitIds: List<Long>
+)
 
 data class SynchronizeCollectionDataForDeviceRequestInput(
     @get:NotNull

--- a/src/main/resources/graphql/deviceRequests.graphqls
+++ b/src/main/resources/graphql/deviceRequests.graphqls
@@ -224,10 +224,16 @@ extend type Query {
     requestCount: RequestCount
 }
 
+input BulkKitAssignmentInput {
+    deviceRequestId: ID!
+    kitIds: [ID!]!
+}
+
 extend type Mutation {
     #Will throw an exception if device requests for the contact exceeds DEVICE_LIMIT with this request
     createDeviceRequest(data: CreateDeviceRequestInput!) : DeviceRequest!
     updateDeviceRequest(data: UpdateDeviceRequestInput!): DeviceRequest!
     deleteDeviceRequest(id: ID!): Boolean
     synchronizeCollectionDataForDeviceRequest(data: SynchronizeCollectionDataForDeviceRequestInput!): DeviceRequest!
+    assignKitsToDeviceRequest(data: BulkKitAssignmentInput!): DeviceRequest!
 }


### PR DESCRIPTION
## Summary
This PR adds a new GraphQL mutation to assign multiple kits to a device request in bulk, along with the necessary input type and repository dependency.

## Key Changes
- Added `assignKitsToDeviceRequest` mutation that accepts a `BulkKitAssignmentInput` containing a device request ID and list of kit IDs
- Implemented bulk kit assignment logic that:
  - Validates the device request exists
  - Filters kits using the existing kit filter service
  - Removes kits from their previous device request assignments (if any)
  - Assigns all kits to the target device request
  - Persists the changes
- Added `BulkKitAssignmentInput` data class with validation for required fields
- Injected `KitRepository` dependency into `DeviceRequestMutations`
- Added corresponding GraphQL schema definition for the new mutation and input type
- Secured the mutation with `@PreAuthorize("hasAnyAuthority('write:organisations')")` authorization

## Implementation Details
- The mutation properly handles kit reassignment by removing kits from their current device request before assigning them to the new one
- Uses the existing `FilterService.kitFilter()` to apply standard kit filtering rules
- Leverages QueryDSL predicates (`QKit`) for flexible kit querying
- Follows the existing mutation pattern and error handling conventions in the codebase

https://claude.ai/code/session_0122W3Tbhtr8otRFaTMPLnWB