### PR TITLE
Optimize startup performance and container resource management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,9 @@ COPY ./Procfile /app
 COPY ./applicationinsights.json /app/
 # COPY ./DOKKU_SCALE /app
 ENTRYPOINT [ "/sbin/tini", "--"]
-CMD ["java", "-javaagent:/app/applicationinsights-agent.jar", "-jar", "/app/app.jar"]
+CMD ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-XX:InitialRAMPercentage=50.0", \
+  "-javaagent:/app/applicationinsights-agent.jar", \
+  "-jar", "/app/app.jar"]

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -11,7 +11,14 @@
     },
     "micrometer": {
       "enabled": true
-    }
+    },
+    "redis": { "enabled": false },
+    "kafka": { "enabled": false },
+    "jms": { "enabled": false },
+    "rabbitmq": { "enabled": false },
+    "mongo": { "enabled": false },
+    "cassandra": { "enabled": false },
+    "quartz": { "enabled": false }
   },
   "preview": {
     "captureHttpServer4xxAsError": false

--- a/src/main/kotlin/cta/app/config/SecurityConfig.kt
+++ b/src/main/kotlin/cta/app/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.authentication.AuthenticationManager
@@ -46,6 +47,7 @@ class SecurityConfig(
     var issuer: String = ""
 
     @Bean
+    @Lazy
     fun jwtDecoder(): JwtDecoder {
         val jwtDecoder = JwtDecoders.fromOidcIssuerLocation(issuer) as NimbusJwtDecoder
         val audienceValidator = AudienceValidator(audience)

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -16,5 +16,10 @@ auth:
           Access-Control-Allow-Methods: 'GET, POST, PUT, PATCH, DELETE, OPTIONS'
           Access-Control-Allow-Headers: '*'
 
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: none
+
 logging.level:
   cta: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,6 +115,8 @@ spring:
     out-of-order: true
     locations:
       - classpath:db/migration
+  main:
+    lazy-initialization: true
   graphql:
     schema:
       inspection:
@@ -135,7 +137,7 @@ logging.level:
   org.apache.coyote: ERROR
   cta: DEBUG
   org.springframework.security: WARN
-  org.hibernate.type: TRACE
+  org.hibernate.type: WARN
 
 auth:
   admin-secret: ${AUTH_ADMIN_SECRET}


### PR DESCRIPTION
## Summary
This PR optimizes application startup performance and improves container resource management through lazy initialization, JVM tuning, and configuration adjustments.

## Key Changes

- **Lazy Initialization**: Enabled Spring's lazy-initialization mode and marked `JwtDecoder` bean as `@Lazy` to defer bean creation until first use, reducing startup time
- **JVM Memory Configuration**: Added container-aware JVM flags to the Docker entrypoint:
  - `UseContainerSupport`: Enables JVM to respect container memory limits
  - `MaxRAMPercentage=75.0`: Limits heap to 75% of container memory
  - `InitialRAMPercentage=50.0`: Sets initial heap to 50% of container memory
- **Hibernate Configuration**: Set `ddl-auto: none` in production profile to prevent automatic schema updates
- **Instrumentation Tuning**: 
  - Disabled Application Insights instrumentation for Redis, Kafka, JMS, RabbitMQ, MongoDB, Cassandra, and Quartz to reduce overhead
  - Reduced Hibernate type logging from TRACE to WARN to decrease log verbosity

## Implementation Details

The lazy initialization strategy defers expensive bean creation (particularly JWT decoder initialization which makes external OIDC calls) until the beans are actually needed, improving cold start times. Combined with container-aware JVM settings, this provides better resource utilization in containerized environments while maintaining application functionality.

https://claude.ai/code/session_01V1secjCGyGRUkbwoGmfQnw