### PR TITLE
Reintegrate bulk kit assignment mutation onto upgraded dev

### DIFF
--- a/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
@@ -8,7 +8,9 @@ import cta.app.DeviceRequestNote
 import cta.app.DeviceRequestNoteRepository
 import cta.app.DeviceRequestRepository
 import cta.app.DeviceRequestStatus
+import cta.app.KitRepository
 import cta.app.KitStatus
+import cta.app.QKit
 import cta.app.ReferringOrganisationContactRepository
 import cta.app.services.FilterService
 import cta.app.services.MailService
@@ -84,6 +86,7 @@ class DeviceRequestMutations(
     private val filterService: FilterService,
     private val deviceRequestNotes: DeviceRequestNoteRepository,
     private val mailService: MailService,
+    private val kits: KitRepository,
 ) {
     @MutationMapping
     fun createDeviceRequest(
@@ -177,6 +180,23 @@ class DeviceRequestMutations(
                 ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.id}")
 
         return data.apply(entity)
+    }
+
+    @PreAuthorize("hasAnyAuthority('write:organisations')")
+    @MutationMapping
+    fun assignKitsToDeviceRequest(@Argument @Valid data: BulkKitAssignmentInput): DeviceRequest {
+        val deviceRequest = deviceRequests.findById(data.deviceRequestId).toNullable()
+            ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.deviceRequestId}")
+
+        val predicate = filterService.kitFilter().and(QKit.kit.id.`in`(data.kitIds))
+        val kitsToAssign = kits.findAll(predicate)
+
+        kitsToAssign.forEach { kit ->
+            kit.deviceRequest?.removeKit(kit)
+            deviceRequest.addKit(kit)
+        }
+
+        return deviceRequests.save(deviceRequest)
     }
 
     @PreAuthorize("hasAnyAuthority('delete:organisations')")
@@ -284,6 +304,12 @@ data class UpdateDeviceRequestInput(
         }
     }
 }
+
+data class BulkKitAssignmentInput(
+    @get:NotNull
+    val deviceRequestId: Long,
+    val kitIds: List<Long>,
+)
 
 data class SynchronizeCollectionDataForDeviceRequestInput(
     @get:NotNull

--- a/src/main/resources/graphql/deviceRequests.graphqls
+++ b/src/main/resources/graphql/deviceRequests.graphqls
@@ -224,10 +224,16 @@ extend type Query {
     requestCount: RequestCount
 }
 
+input BulkKitAssignmentInput {
+    deviceRequestId: ID!
+    kitIds: [ID!]!
+}
+
 extend type Mutation {
     #Will throw an exception if device requests for the contact exceeds DEVICE_LIMIT with this request
     createDeviceRequest(data: CreateDeviceRequestInput!) : DeviceRequest!
     updateDeviceRequest(data: UpdateDeviceRequestInput!): DeviceRequest!
     deleteDeviceRequest(id: ID!): Boolean
     synchronizeCollectionDataForDeviceRequest(data: SynchronizeCollectionDataForDeviceRequestInput!): DeviceRequest!
+    assignKitsToDeviceRequest(data: BulkKitAssignmentInput!): DeviceRequest!
 }


### PR DESCRIPTION
## Summary

- Re-applies the `assignKitsToDeviceRequest` GraphQL mutation (originally master commit `5ddd2f0`, PR #29) that was dropped when production moved to the heavily upgraded `dev` branch.
- This was the only net-new functional enhancement on `master` since `dev` branched off at `1fcdef0` (2026-04-10); the other two master commits were a merge from `dev` (zero net code) and its merge commit.
- Manually re-applied rather than cherry-picked: the Spring Boot 3.4 / jakarta migration and constructor changes caused **context-only** conflicts. All APIs the feature depends on (`KitRepository`/`QuerydslPredicateExecutor`, `QKit`, `filterService.kitFilter()`, `addKit`/`removeKit`, `Kit.deviceRequest`) remain unchanged on `dev`.

Files changed (2 files, +32):
- `src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt`
- `src/main/resources/graphql/deviceRequests.graphqls`

## Test plan

- [x] `./gradlew compileKotlin` — BUILD SUCCESSFUL against upgraded deps (QKit querydsl regenerated cleanly)
- [x] `./gradlew compileTestKotlin` — BUILD SUCCESSFUL
- [ ] Runtime smoke: GraphQL schema loads and `assignKitsToDeviceRequest` mutation resolves (verified post-merge via UAT `api-testing` deploy on push to `dev`)

https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ)_