### PR TITLE
Fix ktlint failure on bulk kit assignment mutation

### DIFF
--- a/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
@@ -184,9 +184,12 @@ class DeviceRequestMutations(
 
     @PreAuthorize("hasAnyAuthority('write:organisations')")
     @MutationMapping
-    fun assignKitsToDeviceRequest(@Argument @Valid data: BulkKitAssignmentInput): DeviceRequest {
-        val deviceRequest = deviceRequests.findById(data.deviceRequestId).toNullable()
-            ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.deviceRequestId}")
+    fun assignKitsToDeviceRequest(
+        @Argument @Valid data: BulkKitAssignmentInput,
+    ): DeviceRequest {
+        val deviceRequest =
+            deviceRequests.findById(data.deviceRequestId).toNullable()
+                ?: throw EntityNotFoundException("Unable to locate a device request with id: ${data.deviceRequestId}")
 
         val predicate = filterService.kitFilter().and(QKit.kit.id.`in`(data.kitIds))
         val kitsToAssign = kits.findAll(predicate)


### PR DESCRIPTION
## Summary

- Follow-up to #32. The merge of #32 into `dev` failed CI on the `ktlintMainSourceSetCheck` step: the new `assignKitsToDeviceRequest` mutation used a single-line parameter signature, while the codebase ktlint config requires wrapped parameter lists and multiline expressions starting on a new line.
- Reformatted the mutation signature and body to match the existing style in this file (verified against `ktlintFormat`).

Verified locally:
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — BUILD SUCCESSFUL
- [x] `./gradlew compileKotlin` — BUILD SUCCESSFUL
- Note: confirmed the new `kits: KitRepository` constructor property does not shadow the pre-existing bare `kits` reference inside `updateDeviceRequest`'s `entity.apply { }` block — the innermost lambda receiver (`DeviceRequest.kits`) still wins, proven by the clean compile.

https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ)_