### PR TITLE
Fix UAT deploy targeting wrong Azure resource group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           az containerapp update \
             --name api-testing \
-            --resource-group dashboards \
+            --resource-group tada-2026 \
             --image ghcr.io/communitytechaid/techaid-server:dev
 
   deploy-production:


### PR DESCRIPTION
## Summary

- The `deploy-testing` (UAT) job in `.github/workflows/ci.yml` targeted resource group `dashboards`, but the `api-testing` container app actually lives in `tada-2026` (the same RG as production). The `az containerapp update` call therefore failed and UAT was never deployed.
- Changed the UAT step's `--resource-group` from `dashboards` to `tada-2026`. Container app name (`api-testing`), image tag (`:dev`), trigger, and auth are unchanged — only the RG was wrong.

## Test plan

- [ ] On merge to `dev`, the `deploy-testing` job runs `az containerapp update --name api-testing --resource-group tada-2026 --image …:dev` and succeeds (no "resource not found").

https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011wdQKf9QTngYC3QZximMwZ)_