### PR TITLE
Wire User/Role nested GraphQL resolvers with @SchemaMapping

### DIFF
--- a/src/main/kotlin/cta/app/graphql/queries/UsersGraph.kt
+++ b/src/main/kotlin/cta/app/graphql/queries/UsersGraph.kt
@@ -13,6 +13,7 @@ import cta.auth.Auth0Service
 import cta.graphql.PaginationInput
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.validation.annotation.Validated
@@ -115,9 +116,10 @@ data class PermissionInput(
 class RoleResolver(
     private val users: Auth0Service,
 ) {
+    @SchemaMapping(typeName = "Role", field = "permissions")
     fun permissions(
         role: Role,
-        page: PaginationInput?,
+        @Argument page: PaginationInput?,
     ): PermissionsPage {
         val filter =
             if (page == null) {
@@ -132,9 +134,10 @@ class RoleResolver(
             .body
     }
 
+    @SchemaMapping(typeName = "Role", field = "users")
     fun users(
         role: Role,
-        page: PaginationInput?,
+        @Argument page: PaginationInput?,
     ): UsersPage {
         val filter =
             if (page == null) {
@@ -154,9 +157,10 @@ class RoleResolver(
 class UserResolver(
     private val users: Auth0Service,
 ) {
+    @SchemaMapping(typeName = "User", field = "roles")
     fun roles(
         user: User,
-        page: PaginationInput?,
+        @Argument page: PaginationInput?,
     ): RolesPage {
         val filter =
             if (page == null) {
@@ -171,9 +175,9 @@ class UserResolver(
             .body
     }
 
-    @QueryMapping
+    @SchemaMapping(typeName = "User", field = "permissions")
     fun permissions(
-        @Argument user: User,
+        user: User,
         @Argument page: PaginationInput?,
     ): PermissionsPage {
         val filter =

--- a/src/test/kotlin/cta/app/graphql/queries/UserRoleNestedResolverWiringTest.kt
+++ b/src/test/kotlin/cta/app/graphql/queries/UserRoleNestedResolverWiringTest.kt
@@ -1,0 +1,47 @@
+package cta.app.graphql.queries
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+
+/**
+ * Regression test for the user/role detail pages showing empty/broken tabs.
+ *
+ * User.roles, User.permissions, Role.users and Role.permissions are backed by the
+ * Auth0 `User`/`Role` POJOs, which have no such property — they require explicit
+ * field resolvers (UserResolver / RoleResolver). After the migration off
+ * graphql-java-kickstart to Spring for GraphQL those methods lost their wiring: with
+ * no @SchemaMapping, graphql-java falls back to the default PropertyDataFetcher, finds
+ * no matching property and resolves the field to null (no GraphQL error). The
+ * dashboard's detail tabs then hung on the null relationship.
+ *
+ * This asserts each nested resolver carries @SchemaMapping pointing at the right
+ * schema coordinates. It's a pure-reflection test (no Spring context / DB) so it runs
+ * without Docker. Before the fix it fails (mapping is null); after it passes.
+ */
+class UserRoleNestedResolverWiringTest {
+    private data class Case(val klass: Class<*>, val method: String, val typeName: String)
+
+    @Test
+    fun `nested user and role relationship fields are wired with @SchemaMapping`() {
+        val cases =
+            listOf(
+                Case(UserResolver::class.java, "roles", "User"),
+                Case(UserResolver::class.java, "permissions", "User"),
+                Case(RoleResolver::class.java, "users", "Role"),
+                Case(RoleResolver::class.java, "permissions", "Role"),
+            )
+        for (c in cases) {
+            val method = c.klass.declaredMethods.firstOrNull { it.name == c.method }
+            assertThat(method).describedAs("${c.klass.simpleName}.${c.method} method exists").isNotNull
+
+            val mapping = method!!.getAnnotation(SchemaMapping::class.java)
+            assertThat(mapping)
+                .describedAs("${c.typeName}.${c.method} must be wired with @SchemaMapping (unwired resolvers resolve to null and break the detail tabs)")
+                .isNotNull
+
+            assertThat(mapping.typeName).describedAs("${c.typeName}.${c.method} typeName").isEqualTo(c.typeName)
+            assertThat(mapping.field).describedAs("${c.typeName}.${c.method} field").isEqualTo(c.method)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Drilling into a user or role in the dashboard leaves every detail tab stuck on "Loading…". The nested relationship fields resolve to **null** (no GraphQL error):

- `user(id).roles` → null
- `user(id).permissions` → null
- `role(id).users` → null
- `role(id).permissions` → null

Verified against UAT for an admin account that definitely has the data.

## Root cause

These fields are backed by the Auth0 `User`/`Role` POJOs (`com.auth0.json.mgmt.*`), which have no `roles`/`users`/`permissions` property — they require explicit field resolvers (`UserResolver` / `RoleResolver` in `UsersGraph.kt`, which call the Auth0 Management API).

The repo migrated **off graphql-java-kickstart to `spring-boot-starter-graphql`** (the kickstart deps are commented out in `build.gradle`). Under kickstart these methods auto-wired by `GraphQLResolver<T>` convention; Spring for GraphQL requires `@SchemaMapping`. The four methods never got it (one had a stray `@QueryMapping` with `@Argument user: User`), so graphql-java fell back to the default `PropertyDataFetcher`, found no matching property, and returned null. `GraphQlConfig.kt` only wires scalars, so there was no alternative data fetcher.

## Fix

Annotate all four resolvers with `@SchemaMapping(typeName = …, field = …)` and add `@Argument` to the `page` parameters (now required under Spring for GraphQL). Surgical — no behavioural change to the Auth0 calls themselves.

## Test plan

New `UserRoleNestedResolverWiringTest` (pure reflection — no Spring context/DB, so it runs without Docker) asserts each nested resolver carries `@SchemaMapping` at the right schema coordinates.

- ✅ `./gradlew test --tests …UserRoleNestedResolverWiringTest` — **passes** with the fix.
- ✅ Verified **red** without the fix (stashed): `User.roles must be wired with @SchemaMapping`.
- ✅ `./gradlew compileKotlin` — clean.

Note: the existing `GraphQlEndpointTest` (and a full request-level test) need the Docker-backed embedded Postgres, which isn't available in this local environment; CI runs those. The reflection test was chosen so the regression is guarded everywhere.

## Related

Front-end null-guard hardening for the same symptom: techaid-dashboard PR #75. (That stops the crash/hang; this restores the data.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)