### PR TITLE
Fix ktlint violations in nested-resolver wiring test

### DIFF
--- a/src/test/kotlin/cta/app/graphql/queries/UserRoleNestedResolverWiringTest.kt
+++ b/src/test/kotlin/cta/app/graphql/queries/UserRoleNestedResolverWiringTest.kt
@@ -20,28 +20,27 @@ import org.springframework.graphql.data.method.annotation.SchemaMapping
  * without Docker. Before the fix it fails (mapping is null); after it passes.
  */
 class UserRoleNestedResolverWiringTest {
-    private data class Case(val klass: Class<*>, val method: String, val typeName: String)
-
     @Test
     fun `nested user and role relationship fields are wired with @SchemaMapping`() {
         val cases =
             listOf(
-                Case(UserResolver::class.java, "roles", "User"),
-                Case(UserResolver::class.java, "permissions", "User"),
-                Case(RoleResolver::class.java, "users", "Role"),
-                Case(RoleResolver::class.java, "permissions", "Role"),
+                Triple(UserResolver::class.java, "roles", "User"),
+                Triple(UserResolver::class.java, "permissions", "User"),
+                Triple(RoleResolver::class.java, "users", "Role"),
+                Triple(RoleResolver::class.java, "permissions", "Role"),
             )
-        for (c in cases) {
-            val method = c.klass.declaredMethods.firstOrNull { it.name == c.method }
-            assertThat(method).describedAs("${c.klass.simpleName}.${c.method} method exists").isNotNull
+        for ((klass, field, typeName) in cases) {
+            val method = klass.declaredMethods.firstOrNull { it.name == field }
+            assertThat(method)
+                .describedAs("$typeName.$field resolver method exists")
+                .isNotNull
 
             val mapping = method!!.getAnnotation(SchemaMapping::class.java)
             assertThat(mapping)
-                .describedAs("${c.typeName}.${c.method} must be wired with @SchemaMapping (unwired resolvers resolve to null and break the detail tabs)")
+                .describedAs("$typeName.$field must be wired with @SchemaMapping")
                 .isNotNull
-
-            assertThat(mapping.typeName).describedAs("${c.typeName}.${c.method} typeName").isEqualTo(c.typeName)
-            assertThat(mapping.field).describedAs("${c.typeName}.${c.method} field").isEqualTo(c.method)
+            assertThat(mapping.typeName).isEqualTo(typeName)
+            assertThat(mapping.field).isEqualTo(field)
         }
     }
 }


### PR DESCRIPTION
Follow-up to #36 (merged). That PR's `UserRoleNestedResolverWiringTest` tripped `ktlintCheck` on the merge to `dev` — `parameter-list-wrapping` on the one-line `data class Case(...)` and a `describedAs` message over the 140-char limit ([failing run](https://github.com/CommunityTechaid/techaid-server/actions/runs/26769932853/job/78906374561)).

This rewrites the test cases as `Triple`s (dropping the data class) and shortens the assertion descriptions. Functionally identical — still asserts each nested resolver carries `@SchemaMapping` at the right schema coordinates.

## Verified
- ✅ `./gradlew ktlintCheck` — clean.
- ✅ `./gradlew test --tests …UserRoleNestedResolverWiringTest` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)