### PR TITLE
ci: consolidate prod deploy into promote.yml; tag images with version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,15 @@ jobs:
         run: |
           IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
           SHA="${GITHUB_SHA::7}"
+          # Project version from build.gradle (release-please bumps this on dev).
+          # Tolerates a trailing `// x-release-please-version` annotation comment.
+          VERSION=$(grep -E "^version = " build.gradle | head -1 | sed -E "s/^version = '([^']*)'.*/\1/")
           if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            # master = production-ready; tag as :latest and :<sha>
-            echo "tags=${IMAGE}:${SHA},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+            # master = production-ready; tag as :latest, :<sha> and :v<version>
+            echo "tags=${IMAGE}:${SHA},${IMAGE}:latest,${IMAGE}:v${VERSION}" >> "$GITHUB_OUTPUT"
           else
-            # dev / maintenance branches = UAT; tag as :dev and :dev-<sha>
-            echo "tags=${IMAGE}:dev-${SHA},${IMAGE}:dev" >> "$GITHUB_OUTPUT"
+            # dev / maintenance branches = UAT; tag as :dev, :dev-<sha> and :v<version>
+            echo "tags=${IMAGE}:dev-${SHA},${IMAGE}:dev,${IMAGE}:v${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,9 @@ name: CI/CD
 on:
   push:
     branches: [dev, master, 'maintenance/**']
-  # Manual production deploy — run from master branch in the GitHub Actions UI.
-  # Optionally specify an image tag (e.g. a short SHA) to pin an exact build.
-  workflow_dispatch:
-    inputs:
-      image_tag:
-        description: 'Image tag to deploy to production (default: latest)'
-        required: false
-        default: 'latest'
 
 jobs:
   test:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +36,6 @@ jobs:
 
   build:
     needs: test
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -90,7 +80,7 @@ jobs:
 
   deploy-testing:
     needs: build
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -110,26 +100,3 @@ jobs:
             --name api-testing \
             --resource-group tada-2026 \
             --image ghcr.io/communitytechaid/techaid-server:dev-${GITHUB_SHA::7}
-
-  deploy-production:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Azure login
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy to api-production
-        run: |
-          az containerapp update \
-            --name api-production \
-            --resource-group tada-2026 \
-            --image ghcr.io/communitytechaid/techaid-server:${{ inputs.image_tag }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,7 +1,15 @@
 name: Promote UAT → Production
 
 on:
+  # Default (no input): promote the image currently running on UAT (api-testing).
+  # Optional image_tag: pin/rollback prod to a specific tag instead, e.g.
+  # "dev-1a2b3c4" or "v2.1.0". Tags are published to GHCR by the CI build job.
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Specific image tag to deploy (leave blank to promote current UAT image)'
+        required: false
+        default: ''
 
 jobs:
   promote:
@@ -19,20 +27,25 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Read current UAT image
-        id: uat
+      - name: Resolve image to deploy
+        id: image
         run: |
-          IMAGE=$(az containerapp show \
-            --name api-testing \
-            --resource-group tada-2026 \
-            --query "properties.template.containers[0].image" \
-            --output tsv)
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            IMAGE="ghcr.io/communitytechaid/techaid-server:${{ inputs.image_tag }}"
+            echo "Pinning production to requested tag: $IMAGE"
+          else
+            IMAGE=$(az containerapp show \
+              --name api-testing \
+              --resource-group tada-2026 \
+              --query "properties.template.containers[0].image" \
+              --output tsv)
+            echo "Promoting current UAT image: $IMAGE"
+          fi
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          echo "Promoting: $IMAGE"
 
       - name: Deploy to api-production
         run: |
           az containerapp update \
             --name api-production \
             --resource-group tada-2026 \
-            --image ${{ steps.uat.outputs.image }}
+            --image ${{ steps.image.outputs.image }}


### PR DESCRIPTION
@
## What

Two related CI changes:

### 1. Remove the redundant `deploy-production` job from `ci.yml`
It was a second, overlapping production-deploy path whose default `image_tag: latest` only ever resolves to `master` builds (stale), so running it with defaults silently shipped an old image. Production is meant to be cut by promoting the image already verified on UAT.

- Removed the `deploy-production` job and the `workflow_dispatch` trigger + `image_tag` input that only existed to feed it.
- Dropped the now-vacuous `github.event_name == push` guards (push is the only remaining trigger).
- **Preserved** the one unique capability it had (deploy/rollback to an arbitrary tag) by adding an optional `image_tag` input to `promote.yml`: blank → promote current UAT image (default); set → pin prod to that exact tag. `promote.yml` is now the single canonical production-deploy workflow.

### 2. Tag built images with `:v<version>`
Adds a human-readable, release-aligned tag alongside `:dev-<sha>` / `:latest`, read from the `build.gradle` project version (the value release-please bumps), tolerating the `// x-release-please-version` annotation. Aids registry browsing and pin/rollback via promote.

## Notes
- Runtime version reporting is unchanged (build-info.properties / the `buildInfo` GraphQL query).
- `master`/`:latest` build path left intact (now a registry snapshot only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@