### PR TITLE
feat: log GraphQL errors with input variables

### DIFF
--- a/src/main/kotlin/cta/app/config/GraphQlTelemetryInterceptor.kt
+++ b/src/main/kotlin/cta/app/config/GraphQlTelemetryInterceptor.kt
@@ -1,11 +1,15 @@
 package cta.app.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.opentelemetry.api.trace.Span
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.graphql.server.WebGraphQlInterceptor
 import org.springframework.graphql.server.WebGraphQlRequest
+import org.springframework.graphql.server.WebGraphQlResponse
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
 
@@ -18,6 +22,9 @@ const val GRAPHQL_OPERATION_REQUEST_ATTRIBUTE = "cta.graphql.operation"
 
 @Configuration
 class GraphQlTelemetryConfig {
+    private val log: Logger = LoggerFactory.getLogger(GraphQlTelemetryConfig::class.java)
+    private val mapper = ObjectMapper()
+
     @Bean
     fun graphQlTelemetryInterceptor(): WebGraphQlInterceptor =
         WebGraphQlInterceptor { request: WebGraphQlRequest, chain: WebGraphQlInterceptor.Chain ->
@@ -39,8 +46,47 @@ class GraphQlTelemetryConfig {
             }
             chain
                 .next(request)
+                .doOnNext { response -> logGraphQlErrors(operationName, request, response) }
                 .doFinally { MDC.remove("graphql.operation") }
         }
+
+    /**
+     * GraphQL errors — including pre-execution validation/variable-coercion errors such as
+     * "Variable 'data' has an invalid value: Expected a String input, but it was a 'Integer'"
+     * — are returned in the response body with HTTP 200. They therefore never reach
+     * [cta.app.services.CustomErrorHandlerConfig] (which only handles data-fetcher exceptions)
+     * and never show up as failed requests in the access log or App Insights.
+     *
+     * Log them here, together with the request's input variables, so malformed inputs (e.g. a
+     * spreadsheet bulk-insert sending a numeric cell into a String field) can be diagnosed.
+     * Variables are JSON-serialised so a number sent into a String field ("model": 3000) is
+     * distinguishable from a valid string value ("model": "3000").
+     *
+     * NOTE: variables may contain personal data for some mutations. This fires only on error
+     * responses, never on successful requests.
+     */
+    private fun logGraphQlErrors(
+        operationName: String?,
+        request: WebGraphQlRequest,
+        response: WebGraphQlResponse,
+    ) {
+        if (response.errors.isEmpty()) return
+        val operation = operationName ?: "<anonymous>"
+        val variables =
+            runCatching { mapper.writeValueAsString(request.variables) }
+                .getOrElse { request.variables.toString() }
+        response.errors.forEach { error ->
+            log.warn(
+                "GraphQL error on operation '{}' [{}]: {} (path={}, locations={}) — input variables: {}",
+                operation,
+                error.errorType,
+                error.message,
+                error.path,
+                error.locations,
+                variables,
+            )
+        }
+    }
 
     private fun resolveOperationName(request: WebGraphQlRequest): String? {
         val explicit = request.operationName

--- a/src/test/kotlin/cta/graphql/GraphQlErrorLoggingTest.kt
+++ b/src/test/kotlin/cta/graphql/GraphQlErrorLoggingTest.kt
@@ -1,0 +1,86 @@
+package cta.graphql
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import cta.app.config.GraphQlTelemetryConfig
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+/**
+ * Verifies that a GraphQL variable-coercion error (returned in the body with HTTP 200) is
+ * logged by [GraphQlTelemetryConfig] together with the offending input variables, so bulk
+ * inserts that send a numeric value into a String field can be diagnosed from the logs.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@AutoConfigureEmbeddedDatabase(type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES)
+class GraphQlErrorLoggingTest {
+    @MockBean
+    lateinit var jwtDecoder: JwtDecoder
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    private val telemetryLogger = LoggerFactory.getLogger(GraphQlTelemetryConfig::class.java) as Logger
+    private val appender = ListAppender<ILoggingEvent>()
+
+    @BeforeEach
+    fun attachAppender() {
+        appender.start()
+        telemetryLogger.addAppender(appender)
+    }
+
+    @AfterEach
+    fun detachAppender() {
+        telemetryLogger.detachAppender(appender)
+        appender.stop()
+    }
+
+    @Test
+    fun `coercion error is logged with operation name and offending input variables`() {
+        // model is String! in CreateKitInput; send a number to reproduce the bulk-insert failure.
+        val body =
+            """
+            {
+              "query": "mutation createKit(${'$'}data: CreateKitInput!) { createKit(data: ${'$'}data) { id } }",
+              "variables": { "data": { "type": "LAPTOP", "model": 3000 } }
+            }
+            """.trimIndent()
+
+        // Accept application/json mirrors the production clients (which see HTTP 200 with the
+        // error in the body); application/graphql-response+json would instead yield HTTP 400.
+        mockMvc
+            .perform(
+                post("/graphql")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(body),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.errors").isArray)
+
+        val warning =
+            appender.list.firstOrNull { it.level == Level.WARN && it.formattedMessage.contains("GraphQL error") }
+
+        assertTrue(warning != null, "expected a WARN log for the GraphQL error")
+        val message = warning!!.formattedMessage
+        assertTrue(message.contains("createKit"), "log should name the failing operation: $message")
+        assertTrue(message.contains("\"model\":3000"), "log should show the offending numeric input: $message")
+        assertTrue(message.contains("String"), "log should include the coercion error text: $message")
+    }
+}


### PR DESCRIPTION
@
## Why

This morning a volunteer hit repeated bulk-insert failures from the Google Sheet + Apps Script device importer:

> Variable 'data' has an invalid value: Expected a String input, but it was a 'Integer'

Investigating via App Insights confirmed **80 `createKit` calls in a 12-minute burst (08:45–08:57 UTC), of which 78 failed at GraphQL variable validation** (fast <15ms, no DB write) and only 2 succeeded. Root cause: a `String`-typed field in `CreateKitInput` (most likely `model`, which is `String!`) received a numeric value from a spreadsheet cell — graphql-java's strict `String` scalar rejects integers.

The problem: **these failures are invisible to our instrumentation.** GraphQL validation/variable-coercion errors are returned in the response body with **HTTP 200**, so they:
- never reach `CustomErrorHandlerConfig` (which only resolves data-fetcher exceptions during execution), and
- never appear as failed requests in the access log or App Insights `AppExceptions`/`AppTraces`.

So we could see *that* `createKit` ran, but never *what* was sent or *why* it failed.

## What

Extend the existing `GraphQlTelemetryInterceptor` (already runs for every request) to log each error in the response — **together with the request's input variables** — whenever the response carries errors.

- Variables are JSON-serialised, so a number sent into a String field (`"model": 3000`) is visibly distinct from a valid string (`"model": "3000"`), pinpointing the offending field and value.
- Logged at WARN, **only on error responses** (never on successful requests).
- Each line includes the operation name, error classification, message, path, locations, and the input variables.

Example line a failed bulk-insert row will now produce:

```
WARN  GraphQL error on operation createKit [ValidationError]: Variable data has an invalid value:
Expected a String input, but it was a Integer (path=null, locations=[...]) —
input variables: {"data":{"type":"LAPTOP","model":3000}}
```

## Privacy note

Variables can contain personal data for some mutations (e.g. contact/device-request creation). This logs them **only when a request errors**, never on success. Flagging for a maintainer's awareness — if that's a concern we can add field redaction in a follow-up.

## Test plan

- `GraphQlErrorLoggingTest` posts a `createKit` mutation with a numeric `model` and asserts the WARN log carries the operation name, the offending `"model":3000` input, and the coercion error text.
- This is a `@SpringBootTest` using the zonky **Docker** Postgres provider (same as the existing `GraphQlEndpointTest`), so it runs in CI but cannot run in my local sandbox (no Docker). Locally verified: `ktlintCheck` + `compileKotlin`/`compileTestKotlin` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@