### PR TITLE
fix: accept numeric values in String input fields

### DIFF
--- a/src/main/kotlin/cta/app/config/GraphQlConfig.kt
+++ b/src/main/kotlin/cta/app/config/GraphQlConfig.kt
@@ -2,6 +2,10 @@ package cta.app.config
 
 import graphql.GraphQLContext
 import graphql.execution.CoercedVariables
+import graphql.language.BooleanValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.StringValue
 import graphql.language.Value
 import graphql.scalars.ExtendedScalars
 import graphql.schema.*
@@ -16,12 +20,17 @@ import java.util.*
 @Configuration
 public class GraphQlConfig {
     @Bean
-    fun runtimeWiringConfigurer(instantScalar: GraphQLScalarType): RuntimeWiringConfigurer =
+    fun runtimeWiringConfigurer(
+        instantScalar: GraphQLScalarType,
+        lenientStringScalar: GraphQLScalarType,
+    ): RuntimeWiringConfigurer =
         RuntimeWiringConfigurer { wiringBuilder: RuntimeWiring.Builder ->
             wiringBuilder
                 .scalar(ExtendedScalars.GraphQLBigDecimal)
                 .scalar(ExtendedScalars.GraphQLLong)
                 .scalar(instantScalar)
+                // Overrides the built-in String scalar (see lenientStringScalar()).
+                .scalar(lenientStringScalar)
         }
 }
 
@@ -66,6 +75,61 @@ class GraphQLScalarConfig {
                             Instant.parse(input.toString())
                         } catch (e: DateTimeParseException) {
                             throw CoercingParseLiteralException("Invalid ISO date-time: $input")
+                        }
+                },
+            ).build()
+
+    /**
+     * Overrides the built-in `String` scalar with lenient input coercion: numbers and booleans
+     * are accepted and stringified, instead of being rejected with
+     * "Expected a String input, but it was a 'Integer'".
+     *
+     * This tolerates bulk/spreadsheet imports that send a numeric cell into a String field — e.g.
+     * a numeric `lotId` (26060301) into `CreateKitInput.lotId`, which is `String`. Output
+     * serialisation is unchanged (the default String coercing already stringifies via toString).
+     * Objects/lists are still rejected, so genuinely structural type errors still surface.
+     */
+    @Bean
+    fun lenientStringScalar(): GraphQLScalarType =
+        GraphQLScalarType
+            .Builder()
+            .name("String")
+            .description("Built-in String scalar with lenient input coercion (numbers and booleans are stringified).")
+            .coercing(
+                object : Coercing<String, String> {
+                    override fun serialize(
+                        dataFetcherResult: Any,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String = dataFetcherResult.toString()
+
+                    override fun parseValue(
+                        input: Any,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String =
+                        when (input) {
+                            is String -> input
+                            is Number, is Boolean -> input.toString()
+                            else -> throw CoercingParseValueException(
+                                "Expected a String, Number or Boolean but was '${input::class.simpleName}'.",
+                            )
+                        }
+
+                    override fun parseLiteral(
+                        input: Value<*>,
+                        variables: CoercedVariables,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String =
+                        when (input) {
+                            is StringValue -> input.value
+                            is IntValue -> input.value.toString()
+                            is FloatValue -> input.value.toString()
+                            is BooleanValue -> input.isValue.toString()
+                            else -> throw CoercingParseLiteralException(
+                                "Expected a scalar literal but was '${input::class.simpleName}'.",
+                            )
                         }
                 },
             ).build()

--- a/src/test/kotlin/cta/app/config/LenientStringScalarTest.kt
+++ b/src/test/kotlin/cta/app/config/LenientStringScalarTest.kt
@@ -1,0 +1,50 @@
+package cta.app.config
+
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
+import graphql.language.IntValue
+import graphql.schema.CoercingParseValueException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+import java.util.Locale
+
+/**
+ * Unit-tests the lenient String coercing in isolation (no Spring context / Docker). Proves that a
+ * numeric value — the bulk-insert failure mode, e.g. a numeric lotId — is now stringified rather
+ * than rejected, while structural values are still refused.
+ */
+class LenientStringScalarTest {
+    private val coercing = GraphQLScalarConfig().lenientStringScalar().coercing
+    private val ctx: GraphQLContext = GraphQLContext.getDefault()
+    private val locale: Locale = Locale.getDefault()
+
+    @Test
+    fun `parseValue stringifies an Integer instead of rejecting it`() {
+        assertEquals("26060301", coercing.parseValue(26060301, ctx, locale))
+    }
+
+    @Test
+    fun `parseValue passes a String through unchanged`() {
+        assertEquals("Latitude", coercing.parseValue("Latitude", ctx, locale))
+    }
+
+    @Test
+    fun `parseValue stringifies a Boolean`() {
+        assertEquals("true", coercing.parseValue(true, ctx, locale))
+    }
+
+    @Test
+    fun `parseValue still rejects a structural (list) value`() {
+        assertThrows(CoercingParseValueException::class.java) {
+            coercing.parseValue(listOf(1, 2), ctx, locale)
+        }
+    }
+
+    @Test
+    fun `parseLiteral stringifies an IntValue literal`() {
+        val literal = IntValue.newIntValue(BigInteger.valueOf(123)).build()
+        assertEquals("123", coercing.parseLiteral(literal, CoercedVariables.emptyVariables(), ctx, locale))
+    }
+}

--- a/src/test/kotlin/cta/graphql/GraphQlErrorLoggingTest.kt
+++ b/src/test/kotlin/cta/graphql/GraphQlErrorLoggingTest.kt
@@ -55,11 +55,13 @@ class GraphQlErrorLoggingTest {
     @Test
     fun `coercion error is logged with operation name and offending input variables`() {
         // model is String! in CreateKitInput; send a number to reproduce the bulk-insert failure.
+        // Invalid KitType enum is a pre-execution validation error that survives the lenient
+        // String scalar (a numeric `model` is now coerced, not rejected — see lenientStringScalar).
         val body =
             """
             {
               "query": "mutation createKit(${'$'}data: CreateKitInput!) { createKit(data: ${'$'}data) { id } }",
-              "variables": { "data": { "type": "LAPTOP", "model": 3000 } }
+              "variables": { "data": { "type": "NOT_A_KIT_TYPE", "model": "Latitude" } }
             }
             """.trimIndent()
 
@@ -80,7 +82,9 @@ class GraphQlErrorLoggingTest {
         assertTrue(warning != null, "expected a WARN log for the GraphQL error")
         val message = warning!!.formattedMessage
         assertTrue(message.contains("createKit"), "log should name the failing operation: $message")
-        assertTrue(message.contains("\"model\":3000"), "log should show the offending numeric input: $message")
-        assertTrue(message.contains("String"), "log should include the coercion error text: $message")
+        assertTrue(
+            message.contains("\"type\":\"NOT_A_KIT_TYPE\""),
+            "log should show the offending input variables: $message",
+        )
     }
 }


### PR DESCRIPTION
@
## Why

The Google Sheet + Apps Script bulk-kit importer was failing with:

> Variable 'data' has an invalid value: Expected a String input, but it was a 'Integer'

The error logging added in #40 captured a real failing row and pinned the cause to a **numeric `lotId`**:

```
input variables: {"data":{ ... "model":"HP Mobile Workstation", "donorId":1915,
  "lotId":26060301, ... }}
```

`CreateKitInput.lotId` is typed `String`, but the sheet computes the lot code as a number (`26060301` ≈ 2026-06-03-01), so Apps Script sends a bare JSON number. graphql-java's strict `String` scalar rejects it.

## What

Override the built-in `String` scalar with **lenient input coercion**: numbers and booleans are stringified on `parseValue`/`parseLiteral` instead of being rejected. This fixes the whole class of "numeric cell in a text field" import failures, for every caller — not just `lotId`.

- **Output unchanged:** graphql-java 22's default String coercing already serialises via `toString()`, so `serialize` keeps the same behaviour.
- **Structural values still rejected:** objects/lists throw, so genuine type mismatches still surface (and are now logged by #40).

## Blast radius — please read

This is **schema-wide**: every `String` *input* field now tolerates a numeric/boolean JSON value. We trade strict input typing on String fields for resilient imports. For our trusted internal callers that's a good trade, and malformed inputs are still logged, but it does mean a client that previously got a validation error for sending a number into a String field will now get silent coercion instead. If we'd rather be surgical, the alternative is a per-field custom scalar (e.g. only `lotId`) — happy to switch.

## Test plan

- `LenientStringScalarTest` — unit-tests the coercing directly (no Spring/Docker): Integer/Boolean stringified, String passed through, list rejected, IntValue literal stringified. **Runs and passes locally.**
- `GraphQlErrorLoggingTest` — updated to trigger its validation error with an invalid enum value (a numeric `model` no longer errors).
- End-to-end wiring (does the running schema actually use the overridden scalar?) runs in CI and will be verified on UAT before any production promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@