### PR TITLE
fix: accept numeric lotId/locationCode/serialNo on kit inputs (LenientString)

### DIFF
--- a/src/main/kotlin/cta/app/config/GraphQlConfig.kt
+++ b/src/main/kotlin/cta/app/config/GraphQlConfig.kt
@@ -2,6 +2,10 @@ package cta.app.config
 
 import graphql.GraphQLContext
 import graphql.execution.CoercedVariables
+import graphql.language.BooleanValue
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.StringValue
 import graphql.language.Value
 import graphql.scalars.ExtendedScalars
 import graphql.schema.*
@@ -16,12 +20,16 @@ import java.util.*
 @Configuration
 public class GraphQlConfig {
     @Bean
-    fun runtimeWiringConfigurer(instantScalar: GraphQLScalarType): RuntimeWiringConfigurer =
+    fun runtimeWiringConfigurer(
+        instantScalar: GraphQLScalarType,
+        lenientStringScalar: GraphQLScalarType,
+    ): RuntimeWiringConfigurer =
         RuntimeWiringConfigurer { wiringBuilder: RuntimeWiring.Builder ->
             wiringBuilder
                 .scalar(ExtendedScalars.GraphQLBigDecimal)
                 .scalar(ExtendedScalars.GraphQLLong)
                 .scalar(instantScalar)
+                .scalar(lenientStringScalar)
         }
 }
 
@@ -66,6 +74,61 @@ class GraphQLScalarConfig {
                             Instant.parse(input.toString())
                         } catch (e: DateTimeParseException) {
                             throw CoercingParseLiteralException("Invalid ISO date-time: $input")
+                        }
+                },
+            ).build()
+
+    /**
+     * A String-like scalar with lenient input coercion: numbers and booleans are accepted and
+     * stringified, instead of being rejected with "Expected a String input, but it was a 'Integer'".
+     *
+     * Applied (in the SDL) to numeric-prone text fields on kit inputs — lotId, locationCode,
+     * serialNo — so bulk/spreadsheet imports that send a numeric cell (e.g. a numeric lotId like
+     * 26060301) no longer fail. It is a distinct scalar name, not a redefinition of the built-in
+     * String, so the schema assembles cleanly. Output serialisation matches the default String
+     * scalar (toString); objects/lists are still rejected so structural mismatches still surface.
+     */
+    @Bean
+    fun lenientStringScalar(): GraphQLScalarType =
+        GraphQLScalarType
+            .Builder()
+            .name("LenientString")
+            .description("A String input that also accepts numbers and booleans, coercing them to their string form.")
+            .coercing(
+                object : Coercing<String, String> {
+                    override fun serialize(
+                        dataFetcherResult: Any,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String = dataFetcherResult.toString()
+
+                    override fun parseValue(
+                        input: Any,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String =
+                        when (input) {
+                            is String -> input
+                            is Number, is Boolean -> input.toString()
+                            else -> throw CoercingParseValueException(
+                                "Expected a String, Number or Boolean but was '${input::class.simpleName}'.",
+                            )
+                        }
+
+                    override fun parseLiteral(
+                        input: Value<*>,
+                        variables: CoercedVariables,
+                        graphQLContext: GraphQLContext,
+                        locale: Locale,
+                    ): String =
+                        when (input) {
+                            is StringValue -> input.value
+                            is IntValue -> input.value.toString()
+                            is FloatValue -> input.value.toString()
+                            is BooleanValue -> input.isValue.toString()
+                            else -> throw CoercingParseLiteralException(
+                                "Expected a scalar literal but was '${input::class.simpleName}'.",
+                            )
                         }
                 },
             ).build()

--- a/src/main/resources/graphql/kits.graphqls
+++ b/src/main/resources/graphql/kits.graphqls
@@ -267,7 +267,7 @@ input CreateKitInput {
     note: CreateNoteInput
     make: String
     deviceVersion: String
-    serialNo: String
+    serialNo: LenientString
     storageCapacity: Int
     typeOfStorage: KitStorageType
     ramCapacity: Int
@@ -275,8 +275,8 @@ input CreateKitInput {
     tpmVersion: String
     cpuCores: Int
     batteryHealth: Int
-    lotId: String
-    locationCode: String
+    lotId: LenientString
+    locationCode: LenientString
     subStatus: KitSubStatusInput
 }
 
@@ -285,8 +285,8 @@ input QuickCreateKitInput {
     make: String
     model: String
     donorId: ID
-    lotId: String
-    locationCode: String
+    lotId: LenientString
+    locationCode: LenientString
 }
 
 
@@ -296,7 +296,7 @@ input AutoCreateKitInput {
     model: String
     make: String
     deviceVersion:String
-    serialNo: String!
+    serialNo: LenientString!
     donorId: ID
     storageCapacity: Int
     typeOfStorage: KitStorageType
@@ -305,8 +305,8 @@ input AutoCreateKitInput {
     tpmVersion: String
     cpuCores: Int
     batteryHealth: Int
-    lotId: String
-    locationCode: String
+    lotId: LenientString
+    locationCode: LenientString
 }
 
 input AutoUpdateKitInput {
@@ -316,7 +316,7 @@ input AutoUpdateKitInput {
     model: String
     make: String,
     deviceVersion:String,
-    serialNo: String,
+    serialNo: LenientString,
     storageCapacity: Int,
     typeOfStorage: KitStorageType,
     ramCapacity: Int,
@@ -324,8 +324,8 @@ input AutoUpdateKitInput {
     tpmVersion: String,
     cpuCores: Int,
     batteryHealth: Int,
-    lotId: String,
-    locationCode: String,
+    lotId: LenientString,
+    locationCode: LenientString,
     subStatus: KitSubStatusInput
 }
 
@@ -343,7 +343,7 @@ input UpdateKitInput {
     note: CreateNoteInput,
     make: String,
     deviceVersion: String,
-    serialNo: String,
+    serialNo: LenientString,
     storageCapacity: Int,
     typeOfStorage: KitStorageType,
     ramCapacity: Int,
@@ -351,8 +351,8 @@ input UpdateKitInput {
     tpmVersion: String,
     cpuCores: Int,
     batteryHealth: Int,
-    lotId: String,
-    locationCode: String,
+    lotId: LenientString,
+    locationCode: LenientString,
     subStatus: KitSubStatusInput
 }
 
@@ -368,8 +368,8 @@ input BulkKitUpdateInput {
     ids: [ID!]!
     status: KitStatus
     archived: Boolean
-    locationCode: String
-    lotId: String
+    locationCode: LenientString
+    lotId: LenientString
 }
 
 extend type Mutation {

--- a/src/main/resources/graphql/root.graphqls
+++ b/src/main/resources/graphql/root.graphqls
@@ -1,6 +1,8 @@
 "Representation of a Java big decimal"
 scalar BigDecimal
 scalar Long
+"A String input that also accepts numbers/booleans and coerces them to their string form (tolerates bulk imports that send a numeric cell into a text field, e.g. a numeric lotId)."
+scalar LenientString
 
 "A class that makes it easier for passing across key/value pairs within graphql"
 input KeyValuePair {

--- a/src/test/kotlin/cta/app/config/LenientStringScalarTest.kt
+++ b/src/test/kotlin/cta/app/config/LenientStringScalarTest.kt
@@ -1,0 +1,50 @@
+package cta.app.config
+
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
+import graphql.language.IntValue
+import graphql.schema.CoercingParseValueException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+import java.util.Locale
+
+/**
+ * Unit-tests the LenientString coercing in isolation (no Spring context / Docker). Proves that a
+ * numeric value — the bulk-insert failure mode, e.g. a numeric lotId — is stringified rather than
+ * rejected, while structural values are still refused.
+ */
+class LenientStringScalarTest {
+    private val coercing = GraphQLScalarConfig().lenientStringScalar().coercing
+    private val ctx: GraphQLContext = GraphQLContext.getDefault()
+    private val locale: Locale = Locale.getDefault()
+
+    @Test
+    fun `parseValue stringifies an Integer instead of rejecting it`() {
+        assertEquals("26060301", coercing.parseValue(26060301, ctx, locale))
+    }
+
+    @Test
+    fun `parseValue passes a String through unchanged`() {
+        assertEquals("Latitude", coercing.parseValue("Latitude", ctx, locale))
+    }
+
+    @Test
+    fun `parseValue stringifies a Boolean`() {
+        assertEquals("true", coercing.parseValue(true, ctx, locale))
+    }
+
+    @Test
+    fun `parseValue still rejects a structural (list) value`() {
+        assertThrows(CoercingParseValueException::class.java) {
+            coercing.parseValue(listOf(1, 2), ctx, locale)
+        }
+    }
+
+    @Test
+    fun `parseLiteral stringifies an IntValue literal`() {
+        val literal = IntValue.newIntValue(BigInteger.valueOf(123)).build()
+        assertEquals("123", coercing.parseLiteral(literal, CoercedVariables.emptyVariables(), ctx, locale))
+    }
+}

--- a/src/test/kotlin/cta/graphql/GraphQlEndpointTest.kt
+++ b/src/test/kotlin/cta/graphql/GraphQlEndpointTest.kt
@@ -1,6 +1,8 @@
 package cta.graphql
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -32,5 +34,39 @@ class GraphQlEndpointTest {
                     .content("""{"query":"{ __typename }"}"""),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data.__typename").value("Query"))
+    }
+
+    @Test
+    fun `numeric value in a LenientString input field is coerced, not rejected`() {
+        // lotId is LenientString; sending it as a number must NOT raise a String-coercion error.
+        // model (String!) is omitted on purpose so the request still fails validation and creates
+        // nothing — making this a safe probe that proves the lenient scalar is wired into the schema.
+        val body =
+            """
+            {
+              "query": "mutation createKit(${'$'}data: CreateKitInput!) { createKit(data: ${'$'}data) { id } }",
+              "variables": { "data": { "type": "LAPTOP", "lotId": 26060301 } }
+            }
+            """.trimIndent()
+
+        val content =
+            mockMvc
+                .perform(
+                    post("/graphql")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        assertTrue(
+            content.contains("\"errors\""),
+            "request should still fail on the missing required model (creating nothing): $content",
+        )
+        assertFalse(
+            content.contains("Expected a String input"),
+            "numeric lotId must be coerced by LenientString, not rejected: $content",
+        )
     }
 }

--- a/src/test/kotlin/cta/graphql/SchemaAssemblyTest.kt
+++ b/src/test/kotlin/cta/graphql/SchemaAssemblyTest.kt
@@ -1,0 +1,49 @@
+package cta.graphql
+
+import cta.app.config.GraphQLScalarConfig
+import graphql.scalars.ExtendedScalars
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+
+/**
+ * Assembles the real schema (every *.graphqls plus the project's custom scalar wiring) with no
+ * Spring context or database. Guards the scalar wiring: the earlier attempt to redefine the
+ * built-in String scalar failed at exactly this step with a graphql.AssertException, which only
+ * surfaced in CI. This turns that class of failure into a fast local check.
+ */
+class SchemaAssemblyTest {
+    @Test
+    fun `schema assembles with custom scalar wiring and exposes LenientString`() {
+        val scalars = GraphQLScalarConfig()
+        val registry = TypeDefinitionRegistry()
+        val parser = SchemaParser()
+        PathMatchingResourcePatternResolver()
+            .getResources("classpath*:graphql/*.graphqls")
+            .forEach { resource ->
+                resource.inputStream.reader().use { reader -> registry.merge(parser.parse(reader)) }
+            }
+
+        val wiring =
+            RuntimeWiring
+                .newRuntimeWiring()
+                .scalar(ExtendedScalars.GraphQLBigDecimal)
+                .scalar(ExtendedScalars.GraphQLLong)
+                .scalar(scalars.instantScalar())
+                .scalar(scalars.lenientStringScalar())
+                .build()
+
+        // Throws graphql.AssertException if a scalar is mis-wired (e.g. redefining a built-in).
+        val schema = SchemaGenerator().makeExecutableSchema(registry, wiring)
+
+        assertNotNull(schema.getType("LenientString"), "LenientString scalar should be in the schema")
+        // lotId on CreateKitInput must resolve to LenientString, not the built-in String.
+        val lotId = (schema.getType("CreateKitInput") as graphql.schema.GraphQLInputObjectType).getField("lotId")
+        assertEquals("LenientString", (lotId.type as graphql.schema.GraphQLNamedType).name)
+    }
+}


### PR DESCRIPTION
## Why

The Google Sheet + Apps Script bulk importer failed with:

> Variable 'data' has an invalid value: Expected a String input, but it was a 'Integer'

The #40 error logging captured the exact culprit — a numeric `lotId`:

```
input variables: {"data":{ ... "lotId":26060301, ... }}
```

`CreateKitInput.lotId` is typed `String`; the sheet computes the lot code numerically, so Apps Script sends a bare JSON number, which graphql-java's strict String scalar rejects.

## What (Option B — surgical)

Introduce a **`LenientString`** scalar — a *distinct* scalar name (not a redefinition of the built-in `String`; that global approach failed schema assembly in #42 and was reverted in #43). Its input coercion accepts numbers/booleans and stringifies them; output matches the default String coercing; objects/lists are still rejected.

Applied in the SDL **only** to the numeric-prone text fields on kit *inputs* — `lotId`, `locationCode`, `serialNo` — across `CreateKitInput`, `QuickCreateKitInput`, `AutoCreateKitInput`, `AutoUpdateKitInput`, `UpdateKitInput`, `BulkKitUpdateInput`.

**Not touched:** the output `Kit` type and the `where`-filter inputs stay `String`. So query results and the dashboard's existing requests are unaffected (the dashboard sends these as strings already, and passes them inside `$data` input objects — no per-field scalar variable to mismatch).

## Test plan

- **`SchemaAssemblyTest`** (local, no Docker) — assembles the real schema from every `*.graphqls` + the project's scalar wiring and asserts `CreateKitInput.lotId` resolves to `LenientString`. This is the exact assembly step that threw in #42; now guarded locally so that class of failure can't regress unseen.
- **`LenientStringScalarTest`** (local, no Docker) — the coercing stringifies Integer/Boolean, passes Strings through, rejects a list.
- **`GraphQlEndpointTest`** (CI, embedded DB) — a numeric `lotId` is coerced with no String-coercion error, and the request still fails on the deliberately-omitted required `model`, so nothing is created.

After merge I'll verify on UAT with a safe probe before any production promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
