### PR TITLE
fix: clear device request collectionDate on explicit null

### DIFF
--- a/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/DeviceRequestMutations.kt
@@ -300,7 +300,11 @@ data class UpdateDeviceRequestInput(
             borough = self.borough ?: entity.borough
             details = self.details
             deviceRequestNeeds = self.deviceRequestNeeds?.entity ?: entity.deviceRequestNeeds
-            collectionDate = parseCollectionDate(self.collectionDate) ?: entity.collectionDate
+            // No `?: entity.collectionDate` fallback: this is a full-replace update and the client
+            // always sends collectionDate, so an explicit null must clear the booking date rather
+            // than preserve the old value. (Partial collection-only sync uses
+            // synchronizeCollectionDataForDeviceRequest, which intentionally keeps its fallback.)
+            collectionDate = parseCollectionDate(self.collectionDate)
             collectionMethod = self.collectionMethod ?: entity.collectionMethod
             collectionContactName = self.collectionContactName ?: entity.collectionContactName
             isPrepped = self.isPrepped ?: entity.isPrepped

--- a/src/test/kotlin/cta/app/graphql/mutations/DeviceRequestMutationsTest.kt
+++ b/src/test/kotlin/cta/app/graphql/mutations/DeviceRequestMutationsTest.kt
@@ -1,0 +1,68 @@
+package cta.app.graphql.mutations
+
+import cta.app.DeviceRequest
+import cta.app.DeviceRequestItems
+import cta.app.ReferringOrganisationContact
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import java.time.Instant
+
+/**
+ * Unit tests for UpdateDeviceRequestInput.apply(). updateDeviceRequest is a full-replace
+ * mutation, so an explicit null collectionDate must CLEAR the booking date (issue: operators
+ * could not remove a collection/delivery booking — see techaid-dashboard #42).
+ */
+class DeviceRequestMutationsTest {
+    private fun entityWithDate(date: Instant?): DeviceRequest =
+        DeviceRequest(
+            id = 1L,
+            deviceRequestItems = DeviceRequestItems(laptops = 1),
+            referringOrganisationContact = mock(ReferringOrganisationContact::class.java),
+            clientRef = "REF001",
+            borough = "Lambeth",
+            details = "test",
+            deviceRequestNeeds = null,
+            collectionDate = date,
+        )
+
+    private fun input(collectionDate: String?): UpdateDeviceRequestInput =
+        UpdateDeviceRequestInput(
+            id = 1L,
+            deviceRequestItems = DeviceRequestItemsInput(laptops = 1),
+            isSales = false,
+            clientRef = "REF001",
+            borough = "Lambeth",
+            details = "test",
+            collectionDate = collectionDate,
+        )
+
+    @Test
+    fun `apply clears collectionDate when input is null`() {
+        val existing = Instant.parse("2026-01-26T13:23:00Z")
+        val entity = entityWithDate(existing)
+
+        input(collectionDate = null).apply(entity)
+
+        assertNull(entity.collectionDate, "explicit null must clear the booking date")
+    }
+
+    @Test
+    fun `apply sets collectionDate when input has a date`() {
+        val entity = entityWithDate(null)
+
+        input(collectionDate = "2027-03-03T09:00:00Z").apply(entity)
+
+        assertEquals(Instant.parse("2027-03-03T09:00:00Z"), entity.collectionDate)
+    }
+
+    @Test
+    fun `apply overwrites an existing collectionDate with a new one`() {
+        val entity = entityWithDate(Instant.parse("2026-01-26T13:23:00Z"))
+
+        input(collectionDate = "2027-03-03T09:00:00Z").apply(entity)
+
+        assertEquals(Instant.parse("2027-03-03T09:00:00Z"), entity.collectionDate)
+    }
+}


### PR DESCRIPTION
## Problem

Operators cannot remove a collection/delivery booking date on a device request. In the dashboard, the **Clear date** button (added in CommunityTechaid/techaid-dashboard#80 and #81) blanks the field and saves, but the date immediately snaps back.

## Root cause

`UpdateDeviceRequestInput.apply()` mapped the date with a preserve-on-null fallback:

```kotlin
collectionDate = parseCollectionDate(self.collectionDate) ?: entity.collectionDate
```

`parseCollectionDate(null)` returns null, so `?: entity.collectionDate` falls back to the **existing** value. An explicit `collectionDate: null` is therefore ignored — the server keeps and returns the old date, which the dashboard's success handler writes back into the form.

Verified against UAT (`api-testing`) with a full payload:

| Sent | Persisted |
|------|-----------|
| a real date | the date ✅ |
| `null` | **old date kept** ❌ |

## Fix

Drop the `?: entity.collectionDate` fallback for `collectionDate`. `updateDeviceRequest` is a full-replace mutation (its input requires non-null `deviceRequestItems`/`clientRef`/`details`) and the dashboard always sends `collectionDate` (a value or null), so an explicit null must clear it.

- `synchronizeCollectionDataForDeviceRequest` (the partial collection-only/calendar sync path) keeps its own preserve-on-null semantics and is **untouched**.
- `collectionMethod` / `collectionContactName` still preserve-on-null. The dashboard always sends their current values, so the clear flow is unaffected. Left as-is to keep this change scoped to the reported bug.

## Test plan

New `DeviceRequestMutationsTest` (pure unit test, no Docker / no `@SpringBootTest`):
- `apply` clears collectionDate when input is null
- `apply` sets collectionDate when input has a date
- `apply` overwrites an existing collectionDate with a new one

```
./gradlew ktlintFormat ktlintCheck    # BUILD SUCCESSFUL
./gradlew test --tests "cta.app.graphql.mutations.DeviceRequestMutationsTest"   # 3 passed
```

This is the backend half required for the dashboard clear-date feature (CommunityTechaid/techaid-dashboard#80, #81) to actually work. Awaits human review before merge.

> Note: dashboard PRs #80/#81 reference "#42" in their titles, but dashboard issue #42 is unrelated ("Verify D&D week-filter UX") — there is no dedicated tracking issue for this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)