### PR TITLE
feat: add notes support to ReferringOrganisationContact (referees)

### DIFF
--- a/src/main/kotlin/cta/app/graphql/mutations/ReferringOrganisationContactMutations.kt
+++ b/src/main/kotlin/cta/app/graphql/mutations/ReferringOrganisationContactMutations.kt
@@ -1,8 +1,10 @@
 package cta.app.graphql.mutations
 
 import cta.app.ReferringOrganisationContact
+import cta.app.ReferringOrganisationContactNote
 import cta.app.ReferringOrganisationContactRepository
 import cta.app.ReferringOrganisationRepository
+import cta.app.services.FilterService
 import cta.toNullable
 import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.Valid
@@ -21,6 +23,7 @@ import org.springframework.validation.annotation.Validated
 class ReferringOrganisationContactMutations(
     private val referringOrganisationContacts: ReferringOrganisationContactRepository,
     private val referringOrganisations: ReferringOrganisationRepository,
+    private val filterService: FilterService,
 ) {
     @MutationMapping
     fun createReferringOrganisationContact(
@@ -78,6 +81,22 @@ class ReferringOrganisationContactMutations(
 
                 referringOrganisation.addContact(this)
             }
+
+            if (data.note != null) {
+                if (data.note.content !== "") {
+                    val volunteer =
+                        filterService.userDetails().name.ifBlank {
+                            filterService.userDetails().email
+                        }
+                    val note =
+                        ReferringOrganisationContactNote(
+                            content = data.note.content,
+                            referringOrganisationContact = this,
+                            volunteer = volunteer,
+                        )
+                    referringOrganisationContactNotes.add(note)
+                }
+            }
         }
     }
 
@@ -117,6 +136,7 @@ data class UpdateReferringOrganisationContactInput(
     @get:NotNull
     var referringOrganisationId: Long,
     val archived: Boolean? = null,
+    val note: ReferringOrganisationContactNoteInput? = null,
 ) {
     fun apply(entity: ReferringOrganisationContact): ReferringOrganisationContact {
         val self = this

--- a/src/main/kotlin/cta/app/graphql/queries/ReferringOrganisationContactQueries.kt
+++ b/src/main/kotlin/cta/app/graphql/queries/ReferringOrganisationContactQueries.kt
@@ -1,6 +1,7 @@
 package cta.app.graphql.queries
 
 import cta.app.ReferringOrganisationContact
+import cta.app.ReferringOrganisationContactNote
 import cta.app.ReferringOrganisationContactRepository
 import cta.app.graphql.filters.ReferringOrganisationContactPublicWhereInput
 import cta.app.graphql.filters.ReferringOrganisationContactWhereInput
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Sort
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import java.util.Optional
@@ -66,6 +68,9 @@ class ReferringOrganisationContactQueries(
     fun referringOrganisationContact(
         @Argument where: ReferringOrganisationContactWhereInput,
     ): Optional<ReferringOrganisationContact> = referringOrganisationContacts.findOne(where.build())
+
+    @SchemaMapping(typeName = "ReferringOrganisationContact", field = "notes")
+    fun notes(contact: ReferringOrganisationContact): Set<ReferringOrganisationContactNote> = contact.referringOrganisationContactNotes
 }
 
 data class ReferringOrganisationContactPublic(

--- a/src/main/resources/graphql/referringOrganisationContact.graphqls
+++ b/src/main/resources/graphql/referringOrganisationContact.graphqls
@@ -9,6 +9,7 @@ type ReferringOrganisationContact {
     updatedAt: String
     referringOrganisation: ReferringOrganisation
     requestCount: Int
+    notes: [ReferringOrganisationContactNotes]
 }
 
 "A representation of a page result from a query"
@@ -53,6 +54,7 @@ input UpdateReferringOrganisationContactInput {
     phoneNumber: String
     referringOrganisationId: ID
     archived: Boolean
+    note: ReferringOrganisationContactNoteInput
 }
 
 input ReferringOrganisationContactWhereInput {

--- a/src/test/kotlin/cta/app/graphql/queries/ReferringOrganisationContactNotesResolverWiringTest.kt
+++ b/src/test/kotlin/cta/app/graphql/queries/ReferringOrganisationContactNotesResolverWiringTest.kt
@@ -1,0 +1,35 @@
+package cta.app.graphql.queries
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.graphql.data.method.annotation.SchemaMapping
+
+/**
+ * Guards the ReferringOrganisationContact.notes nested field resolver.
+ *
+ * The entity collection is named `referringOrganisationContactNotes`, but the GraphQL field is
+ * `notes` (matching Kit's convention so the dashboard can reuse the same shape). With no
+ * @SchemaMapping bridging the name mismatch, graphql-java falls back to the default
+ * PropertyDataFetcher, finds no `notes` property and resolves the field to null with no error —
+ * the same silent-null failure mode covered by UserRoleNestedResolverWiringTest.
+ *
+ * Pure-reflection test (no Spring context / DB) so it runs without Docker.
+ */
+class ReferringOrganisationContactNotesResolverWiringTest {
+    @Test
+    fun `ReferringOrganisationContact notes field is wired with @SchemaMapping`() {
+        val method =
+            ReferringOrganisationContactQueries::class.java.declaredMethods
+                .firstOrNull { it.name == "notes" }
+        assertThat(method)
+            .describedAs("ReferringOrganisationContact.notes resolver method exists")
+            .isNotNull
+
+        val mapping = method!!.getAnnotation(SchemaMapping::class.java)
+        assertThat(mapping)
+            .describedAs("ReferringOrganisationContact.notes must be wired with @SchemaMapping")
+            .isNotNull
+        assertThat(mapping.typeName).isEqualTo("ReferringOrganisationContact")
+        assertThat(mapping.field).isEqualTo("notes")
+    }
+}


### PR DESCRIPTION
## Why

The dashboard wants a notes/context box on the Referee detail page (techaid-dashboard issue #65 / B-06). The frontend is ready to build it the moment the backend exposes the same notes shape it already consumes for `Kit` and `DeviceRequest`. `ReferringOrganisationContact` had no notes wired into GraphQL, which blocked the frontend.

## What

Wires contact-level notes onto `ReferringOrganisationContact`, mirroring the existing pattern on `Kit`/`DeviceRequest`:

1. **Read** — `ReferringOrganisationContact` now exposes `notes { id content volunteer createdAt updatedAt }`. The entity collection is `referringOrganisationContactNotes`; a `@SchemaMapping(typeName = "ReferringOrganisationContact", field = "notes")` resolver bridges it to the plain `notes` field name (matching Kit's convention, per the frontend's stated preference).
2. **Create** — `UpdateReferringOrganisationContactInput` gains an optional `note: ReferringOrganisationContactNoteInput`. Saving a contact with a populated `note.content` creates a new note linked to that contact; `volunteer` and timestamps are set server-side exactly as for Kit/DeviceRequest (the frontend only sends `content`).
3. **Delete** — `deleteReferringOrganisationContactNote(id: ID!): Boolean` already existed and is unchanged. Same `write:organisations` authority guards create (via the update mutation) and delete, consistent with DeviceRequest notes.

The `ReferringOrganisationContactNote` entity, repository, delete mutation and the `ReferringOrganisationContactNotes` / `ReferringOrganisationContactNoteInput` GraphQL types already existed on `dev`; this PR wires the create/read path that was missing.

### Final contract for the frontend
- Notes field name: **`notes`** (not prefixed)
- Update-input field name: **`note`** (type `ReferringOrganisationContactNoteInput`, shape `{ content }`)
- Delete mutation: **`deleteReferringOrganisationContactNote(id: ID!): Boolean`**

### Migration
No Flyway migration added. Every `referring_*` table and every `*_notes` table in this project (including Kit's `note` and `device_requests_notes`) is provisioned by Hibernate `ddl-auto`, not Flyway — the `referring_organisation_contacts_notes` table is created the same way. Adding a migration would diverge from that established convention and risk DDL drift.

## Testing
- `SchemaAssemblyTest` passes — full schema (with new `notes`/`note`) assembles cleanly.
- New `ReferringOrganisationContactNotesResolverWiringTest` guards the nested `notes` resolver wiring (same silent-null bug class as the existing `UserRoleNestedResolverWiringTest`).
- `compileKotlin` clean.

## Acceptance (to confirm on UAT)
```graphql
{ __type(name: "ReferringOrganisationContact") { fields { name } } }                 # expect: notes
{ __type(name: "UpdateReferringOrganisationContactInput") { inputFields { name } } } # expect: note
```
Then update a referee with `note: { content: "test" }`, re-query `notes`, confirm `volunteer`/`createdAt`/`updatedAt` are populated, and confirm `deleteReferringOrganisationContactNote` removes it.

https://claude.ai/code/session_01AN3JtpBHqxgg2TRrWJYzhq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN3JtpBHqxgg2TRrWJYzhq)_